### PR TITLE
Build UMD modules in root['cozy']

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -5,8 +5,9 @@ const path = require('path')
 module.exports = {
   entry: path.resolve(__dirname, '../src/'),
   output: {
-    library: 'cozy-bar',
-    libraryTarget: 'umd'
+    library: ['cozy', 'bar'],
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
   resolve: {
     extensions: ['', '.js', '.svelte', '.json', '.yaml', '.css']

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "standard 'src/**/*.js'",
     "prebuild": "npm-run-all lint clean",
     "prewatch": "npm-run-all clean",
-    "watch": "NODE_ENV=development webpack-dev-server --config ./config/webpack.target.standalone.js  --content-base public --port 8082 --display-modules --display-chunks --inline --hot"
+    "watch": "NODE_ENV=development webpack --config ./config/webpack.target.split.js --watch --display-chunks",
+    "watch:standalone": "NODE_ENV=development webpack-dev-server --config ./config/webpack.target.standalone.js  --content-base public --port 8082 --display-modules --display-chunks --inline --hot"
   },
   "devDependencies": {
     "autoprefixer": "^6.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const injectDOM = function CozyBarInjectDOM ({lang, appName, iconPath}) {
   const appNode = document.querySelector('[role=application]')
   document.body.insertBefore(barNode, appNode)
 
-  cozy.bar.__view__ = new BarView({
+  bar.__view__ = new BarView({
     target: barNode,
     data: {lang, appName, iconPath}
   })
@@ -44,24 +44,11 @@ const init = function CozyBarInit ({lang = getDefaultLang(), appName, iconPath =
   i18n(lang)
   injectDOM({lang, appName, iconPath})
   document.body.addEventListener('click', () => {
-    cozy.bar.__view__.fire('clickOutside')
+    bar.__view__.fire('clickOutside')
   })
+  console.debug('HELLO WORLD!')
 }
 
-const Cozy = window.Cozy || class Cozy {}
+const bar = { init }
 
-Object.assign(Cozy.prototype, {
-  bar: {
-    init
-  }
-})
-
-const cozy = window.cozy || new Cozy()
-
-if ((typeof window) !== 'undefined' && window.cozy == null) {
-  window.cozy = cozy
-  window.Cozy = Cozy
-}
-
-export default cozy
-export { Cozy }
+module.exports = bar


### PR DESCRIPTION
This PR ensure we build a real UMD module, and exposes it at root level under the namespace `cozy` (i.e. `window.cozy.client`)