### PR TITLE
feat: Add request to disk quota

### DIFF
--- a/src/components/NavigationItem.svelte
+++ b/src/components/NavigationItem.svelte
@@ -3,7 +3,7 @@
   <div role='menuitem' data-icon='{{dataIcon?dataIcon:""}}' aria-busy='{{isBusy}}'>
     {{label}}
     {{#if item.component === 'storage'}}
-    <Storage diskUsageFromStack='{{item.currentDiskUsage}}' />
+    <Storage diskUsageFromStack='{{item.currentDiskUsage}}' diskQuotaFromStack='{{item.currentDiskQuota}}' />
     {{/if}}
   </div>
   {{elseif item.href}}

--- a/src/components/Storage.svelte
+++ b/src/components/Storage.svelte
@@ -3,12 +3,12 @@
   <p class='coz-nav-storage-text'>
     {{t('storage_phrase', {
       diskUsage: diskUsage,
-      totalStorage: totalStorage
+      diskQuota: diskQuota
     })}}
   </p>
   <progress
     class='cozy-nav-storage-bar'
-    value='{{diskUsage}}' max='{{totalStorage}}' min='0'
+    value='{{diskUsage}}' max='{{diskQuota}}' min='0'
   />
   {{elseif diskUsage && diskUsage.error}}
   <p class='coz-nav--error'>
@@ -21,13 +21,13 @@
   import { t } from '../lib/i18n'
 
   export default {
-    data() {
-      return {
-        totalStorage: 60 // TODO grab it from the cozy stack
-      }
-    },
-
     computed: {
+      diskQuota: diskQuotaFromStack => {
+        if (Number.isInteger(diskQuotaFromStack)) {
+            return (diskQuotaFromStack/1000000000).toFixed(2)
+        }
+        return diskQuotaFromStack
+    },
       diskUsage: diskUsageFromStack => {
         if (Number.isInteger(diskUsageFromStack)) {
             return (diskUsageFromStack/1000000000).toFixed(2)

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -54,6 +54,18 @@ async function updateDiskUsage (config) {
   config.components.storage.currentDiskUsage = currentDiskUsage
 }
 
+async function updateDiskQuota (config) {
+  let currentDiskQuota
+
+  try {
+    currentDiskQuota = await stack.get.diskQuota()
+  } catch (e) {
+    currentDiskQuota = { error: e.name }
+  }
+
+  config.components.storage.currentDiskQuota = currentDiskQuota
+}
+
 /**
  * Add / Remove settings' links items regarding the status of
  * the `settings` app
@@ -149,6 +161,7 @@ async function updateSettings (config, {storage = true, items = true} = {}) {
   if (storage) {
     const oldDiskUsage = config.components.storage.currentDiskUsage
     await updateDiskUsage(config)
+    await updateDiskQuota(config)
     valve = valve || oldDiskUsage !== config.components.storage.currentDiskUsage
   }
 

--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -61,7 +61,13 @@ function getDiskQuota () {
 
     return res.json()
   })
-  .then(json => parseInt(json.data.attributes.quota, 10))
+  .then(json => {
+    if (Number.isInteger(json.data.attributes.quota)) {
+      return parseInt(json.data.attributes.quota, 10)
+    } else {
+      return 100000000000 // @TODO Waiting for instructions about how to deal with limitless instances
+    }
+  })
   .catch(e => {
     throw new UnavailableStackException()
   })

--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -52,6 +52,21 @@ function getDiskUsage () {
   })
 }
 
+function getDiskQuota () {
+  return fetch(`${COZY_URL}/settings/disk-usage`, fetchOptions())
+  .then(res => {
+    if (res.status === 401) {
+      throw new UnauthorizedStackException()
+    }
+
+    return res.json()
+  })
+  .then(json => parseInt(json.data.attributes.quota, 10))
+  .catch(e => {
+    throw new UnavailableStackException()
+  })
+}
+
 function getApp (slug) {
   return getApps().then(apps => apps.find(item => item.attributes.slug === slug))
 }
@@ -100,6 +115,7 @@ module.exports = {
     app: getApp,
     apps: getApps,
     diskUsage: getDiskUsage,
+    diskQuota: getDiskQuota,
     icon: getIcon,
     cozyURL () {
       return COZY_URL

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,7 +6,7 @@
   "profile": "Profile",
   "connectedDevices": "Connected devices",
   "storage": "Storage",
-  "storage_phrase": "%{diskUsage} GB of %{totalStorage} GB used",
+  "storage_phrase": "%{diskUsage} GB of %{diskQuota} GB used",
   "help": "Help",
   "email": "Send an email to support",
   "logout": "Sign out",


### PR DESCRIPTION
Basically I just copied and pasted what existed before for disk usage. I tried to do both with a one shot request but couldn't get this thing to work with an object instead of a single string.

Also, i didn't copied the part where the data self update, considering that a quota on the disk isn't something that changes frequently and that only one request on the loading of the app is enough.

To test this you should use an updated version of Cozy-stack and launch it manually. Once you're done just use the following commands:
- Use your local (updated) repo of Files (aka Drive) with a `yarn link cozy-bar` in it.
- Then start you stack server with an appropriate path to your local Files' repo:
`cozy-stack serve --appdir drive:$HOME/Repos/cozy-files-v3/build/` 
- Add your instance with a defined quota:
`cozy-stack instances add --dev --disk-quota 50000000000 --passphrase cozy cozy.tools:8080`


**NB: I realized that the stack has an option to say that a cozy instance has a limited quota or not. This PR only takes care of the case with limited quota. If your instance doesn't have a limited quota, you'll have a default quota of 100GB.**