### PR TITLE
fix: remove features on mobile

### DIFF
--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -48,8 +48,10 @@
     async onrender () {
       const config = this.get('config')
 
-      await updateSettings(config)
-      await updateApps(config)
+      if (this.get('target') !== 'mobile') {
+        await updateSettings(config)
+        await updateApps(config)
+      }
 
       this.set({ config })
     },


### PR DESCRIPTION
We get errors when cozy-bar setups two features on mobile phone, specially visible when running on offline mode:

- disk-usage statistics
- other apps access

Best solution found: don't setup those features when `target === mobile`. Is this cool?