### PR TITLE
feat: Add support for editor's name in the app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ Once you have the library included in your application, starts by intialize it i
 ```js
 window.cozy.bar.init({
   appName: MY_APP_NAME,
+  appEditor: APP_EDITOR
   iconPath: PATH_TO_SVG_ICON,
   lang: LOCALE
 })
 ```
 
-`appName` param in hash is mandatory when `lang` and `iconPath` are optionals. If not passed, their values are detected into the DOM:
+`appName` param in hash is mandatory when `appEditor`, `lang` and `iconPath` are optionals. If not passed, their values are detected into the DOM:
 
+- `appEditor` is extracted from the manifest. Originally used for apps maintained by Cozy Cloud teams.
 - `lang` is extracted from the `lang` attribute of the `<html>` tag. Defaults to 'en'
 - `iconPath` uses the favicon 32px. Defaults to a blank GIF
 

--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -6,7 +6,7 @@
 
 <h1 class='{{titleClass}}'>
   <img class='coz-bar-hide-sm' src='{{iconPath}}' width='32' />
-  <span class='coz-bar-hide-sm'>cozy </span><strong>{{appName}}</strong>
+  <span class='coz-bar-hide-sm'>{{appEditor}} </span><strong>{{appName}}</strong>
 </h1>
 
 <hr class='coz-sep-flex' />

--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -6,7 +6,8 @@
 
 <h1 class='{{titleClass}}'>
   <img class='coz-bar-hide-sm' src='{{iconPath}}' width='32' />
-  <span class='coz-bar-hide-sm'>{{appEditor}} </span><strong>{{appName}}</strong>
+  {{#if appEditor}}<span class='coz-bar-hide-sm'>{{appEditor}} </span>{{/if}}
+  <strong>{{appName}}</strong>
 </h1>
 
 <hr class='coz-sep-flex' />

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,15 @@ const getDefaultLang = function GetDefaultLang () {
   return document.documentElement.getAttribute('lang') || 'en'
 }
 
+const getEditor = function GetEditor () {
+  const appNode = document.querySelector(APP_SELECTOR)
+  if (!appNode) {
+    console.warn(`Cozy-bar can't discover the app's Editor, and will probably fail to initialize the connection with the stack.`)
+    return ''
+  }
+  return appNode.dataset.cozyEditor || ''
+}
+
 const getDefaultIcon = function GetDefaultIcon () {
   const linkNode = document.querySelector('link[rel="icon"][sizes^="32"]')
   if (linkNode !== null) {
@@ -125,6 +134,7 @@ const getDefaultIcon = function GetDefaultIcon () {
 const init = function CozyBarInit ({
   lang = getDefaultLang(),
   appName,
+  appEditor = getEditor(),
   iconPath = getDefaultIcon(),
   cozyURL = getDefaultStackURL(),
   token = getDefaultToken(),
@@ -132,7 +142,7 @@ const init = function CozyBarInit ({
 } = {}) {
   i18n(lang)
   stack.init({cozyURL, token})
-  const view = injectDOM({lang, appName, iconPath, replaceTitleOnMobile})
+  const view = injectDOM({lang, appName, appEditor, iconPath, replaceTitleOnMobile})
 
   if (view) {
     bindEvents.call(view)

--- a/src/index.js
+++ b/src/index.js
@@ -115,11 +115,7 @@ const getDefaultLang = function GetDefaultLang () {
 
 const getEditor = function GetEditor () {
   const appNode = document.querySelector(APP_SELECTOR)
-  if (!appNode) {
-    console.warn(`Cozy-bar can't discover the app's Editor, and will probably fail to initialize the connection with the stack.`)
-    return ''
-  }
-  return appNode.dataset.cozyEditor || ''
+  return appNode.dataset.cozyEditor || undefined
 }
 
 const getDefaultIcon = function GetDefaultIcon () {

--- a/src/styles/bar.css
+++ b/src/styles/bar.css
@@ -30,7 +30,6 @@
   align-items: center;
   font-size: 1.5em;
   font-weight: normal;
-  text-transform: lowercase;
   color: var(--grey-08);
 }
 

--- a/src/styles/bar.css
+++ b/src/styles/bar.css
@@ -43,8 +43,11 @@
   margin-right: .45em;
 }
 
+[role=banner] .coz-bar-title span {
+  margin-right: .25em;
+}
+
 [role=banner] .coz-bar-title strong {
-  padding-left: .25em;
   font-weight: bold;
 }
 


### PR DESCRIPTION
So basically the **Cozy-Bar** gets the editor's name from the data attribute `data-cozy-app-editor` on the `[role=application]` div within the App (e.g. **Drive**) which is populated by the **Stack** while reading the `manifest.webapp` of the **Drive** App. Do you follow?

Related PR: https://github.com/cozy/cozy-stack/pull/484