### PR TITLE
fix: broken layout because of vh unit on mobile browsers

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,9 +1,13 @@
+html {
+  height: 100%;
+}
+
 body {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   width: 100vw;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -11,7 +15,7 @@ body {
 [role=application] {
   display: flex;
   height: inherit;
-  flex: 1 1 100vh;
+  flex: 1 1 100%;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Using `100vh` for the height of the application caused some issues on some mobile browsers.

Basically `100vh` is **not** 100% of the viewport's height, but a little more than that. Why? Because why the fuck not, said browser vendors. 😎
(See https://nicolas-hoizey.com/2015/02/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers.html for more information)

So I had to get back to the old fashioned way using a `height: 100%` instead. Didn't touch the `width 100vw` because it's not an issue. For now at least.