### PR TITLE
chore: Remove useless layout style

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,25 +1,3 @@
-html {
-  height: 100%;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  width: 100vw;
-  height: 100%;
-  overflow: hidden;
-}
-
-
-[role=application] {
-  display: flex;
-  height: inherit;
-  flex: 1 1 100%;
-  overflow-y: auto;
-}
-
-
 [role=banner] .coz-sep-flex {
   margin: 0;
   border: none;


### PR DESCRIPTION
I had to moved that style to Cozy-UI because on the mobile app it triggers some kind of ugly repaint where the nav briefly appears on top of the viewport before going down at its rightful place.

Moving that style to UI don't cause the repaint because there's no overwrite anymore so it kinda fix this bug. Furthermore, as the layout evolved I don't think it's needed anymore to have this overwrite of the layout style from the cozy-bar.
Loading an app without the cozy-bar doesn't cause any issue and with cozy-bar we don't have the repaint anymore.

What do you think @m4dz? 