### PR TITLE
Add public mode

### DIFF
--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -1,4 +1,4 @@
-{{#if target !== 'mobile'}}
+{{#if target !== 'mobile' && !isPublic}}
 <button class='coz-bar-burger' on:click='toggleDrawer()' data-icon='icon-hamburger'>
   <span class='coz-bar-hidden'>{{t('menu')}}</span>
 </button>
@@ -12,9 +12,11 @@
 
 <hr class='coz-sep-flex' />
 
+{{#if !isPublic}}
 <Navigation sections='{{config.sections.bar}}' on:open='onPopOpen(event.panel)' />
+{{/if}}
 
-{{#if target !== 'mobile'}}
+{{#if target !== 'mobile' && !isPublic}}
 <Drawer content='{{config.apps}}' footer='{{config.sections.drawer}}' visible={{drawerVisible}} on:close='toggleDrawer(true)'/>
 {{/if}}
 

--- a/src/index.js
+++ b/src/index.js
@@ -136,11 +136,17 @@ const init = function CozyBarInit ({
   iconPath = getDefaultIcon(),
   cozyURL = getDefaultStackURL(),
   token = getDefaultToken(),
-  replaceTitleOnMobile = false
+  replaceTitleOnMobile = false,
+  isPublic = false
 } = {}) {
+  // Force public mode in `/public` URLs
+  if (/^\/public/.test(window.location.pathname)) {
+    isPublic = true
+  }
+
   i18n(lang)
   stack.init({cozyURL, token})
-  view = injectDOM({lang, appName, appEditor, iconPath, replaceTitleOnMobile})
+  view = injectDOM({lang, appName, appEditor, iconPath, replaceTitleOnMobile, isPublic})
 
   if (view) {
     bindEvents.call(view)


### PR DESCRIPTION
We sometimes need to load the Cozy Bar in a lightweight mode, i.e. w/o navigation menus. This PR adds a `isPublic` init param (set to `false` by default) that allows to initialize the Bar w/o loading the navigation items nor the drawer.

It also forces this mode of the current page that init the bar is a `/public` URL.