### PR TITLE
Fix apps icon display issue on safari

### DIFF
--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -78,10 +78,18 @@ function getApp (slug) {
   return getApps().then(apps => apps.find(item => item.attributes.slug === slug))
 }
 
-function getIcon (url) {
-  return fetch(`${COZY_URL}${url}`, fetchOptions())
-  .then(res => res.blob())
-  .then(blob => URL.createObjectURL(blob))
+async function getIcon (url) {
+  const res = await fetch(`${COZY_URL}${url}`, fetchOptions())
+  // res.text if SVG, otherwise res.blob  (mainly for safari support)
+  const resClone = res.clone() // res must be cloned to be used twice
+  const blob = await res.blob()
+  const text = await resClone.text()
+
+  try {
+    return 'data:image/svg+xml;base64,' + btoa(text)
+  } catch (e) { // eslint-disable-line
+    return URL.createObjectURL(blob)
+  }
 }
 
 function hasApp (slug) {


### PR DESCRIPTION
__Issue:__ Safari seems to not display correctly `.svg` image using `Blob`, so the apps menu was full of broken icons. This PR should fix it.

__Solution:__ When the response from the stack is an`.svg` we have to use `data:base64` syntax to display in Safari but that broke other image formats which need the `Blob` usage (tested with `.png` for here) in Safari and in other browsers.
However, it seems that the binary data (all but `.svg` so) throw an error when trying to encode it in base64 using `btoa()`, so I used this error to make the distinction between `.svg` and other formats here.