### PR TITLE
fix: lower paddings on list in drawer

### DIFF
--- a/src/styles/drawer.css
+++ b/src/styles/drawer.css
@@ -55,6 +55,12 @@
   list-style-type: none;
 }
 
+@media (max-width: 48em) {
+    [role=banner] .coz-drawer-wrapper ul {
+        padding: .5em 0;
+    }
+}
+
 [role=banner] .coz-drawer-wrapper nav hr {
   margin: 0;
   border: none;


### PR DESCRIPTION
Used to be .8em from mobile to desktop.
It's now .5em on mobile as requested by @kelukelu 