### PR TITLE
Display Claudy according to the context + minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - none yet
 
+## [v3.1.0] - 2017-06-XX
+### Changed
+- none yet
+
+### Fixed
+- none yet
+
+### Added
+- Claudy: a list of actions available for the Cozy and suggested to the user (according the Cozy context setting)
+
+### Removed
+- none yet
+
 
 ## [v3.0.1] - 2017-06-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Coming Soon application
 ---
 Coming Soon applications (or apps) are defined in your Cozy's [configuration file](https://github.com/cozy/cozy-stack/blob/master/docs/config.md#main-configuration-file). See the `cozy.example.yaml` file [provided by the stack](https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml#L80).
 
+Claudy actions list
+---
+Claudy actions are declared in `src/config/claudy.yaml` with a slug as property name and some options (icon name and link options for example). The slugs list that will be used for Claudy is defined in your Cozy's [configuration file](https://github.com/cozy/cozy-stack/blob/master/docs/config.md#main-configuration-file). See the `cozy.example.yaml` file [provided by the stack](https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml#L101).
+If no `claudy_actions` property is defined in the configuration, Claudy won't be displayed.
+
 Contribute
 ----------
 

--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -19,12 +19,14 @@
 
 {{#if target !== 'mobile' && !isPublic}}
 <Drawer content='{{config.apps}}' footer='{{config.sections.drawer}}' visible={{drawerVisible}} on:close='toggleDrawer(true)'/>
-<Claudy config='{{claudyConfig}}' appsList='{{config.apps}}'/>
+  {{#if claudyConfig}}
+    <Claudy config='{{claudyConfig}}' appsList='{{config.apps}}'/>
+  {{/if}}
 {{/if}}
 
 <script>
   import { t } from '../lib/i18n'
-  import { createMenuPointers, updateSettings, updateApps } from '../lib/config'
+  import { createMenuPointers, updateSettings, updateApps, getClaudyConfig } from '../lib/config'
 
   import Navigation from './Navigation'
   import Drawer from './Drawer'
@@ -40,7 +42,7 @@
       return {
         target: __TARGET__,
         config,
-        claudyConfig: CLAUDY_CONFIG,
+        claudyConfig: null, // no claudy by default
         drawerVisible: false
       }
     },
@@ -60,12 +62,14 @@
         this.set({config}) // force to rerender when locale change
       })
 
+      let claudyConfig = null
       if (this.get('target') !== 'mobile' && !this.get('isPublic')) {
+        claudyConfig = await getClaudyConfig()
         await updateSettings(config)
         await updateApps(config)
       }
 
-      this.set({ config })
+      this.set({ config, claudyConfig })
     },
 
     components: {

--- a/src/components/Bar.svelte
+++ b/src/components/Bar.svelte
@@ -19,7 +19,7 @@
 
 {{#if target !== 'mobile' && !isPublic}}
 <Drawer content='{{config.apps}}' footer='{{config.sections.drawer}}' visible={{drawerVisible}} on:close='toggleDrawer(true)'/>
-<Claudy config='{{clouzyConfig}}' appsList='{{config.apps}}'/>
+<Claudy config='{{claudyConfig}}' appsList='{{config.apps}}'/>
 {{/if}}
 
 <script>
@@ -40,7 +40,7 @@
       return {
         target: __TARGET__,
         config,
-        clouzyConfig: CLAUDY_CONFIG,
+        claudyConfig: CLAUDY_CONFIG,
         drawerVisible: false
       }
     },

--- a/src/components/Claudy.svelte
+++ b/src/components/Claudy.svelte
@@ -1,6 +1,6 @@
 <div class='{{`coz-claudy coz-bar-hide-sm ${opened ? "coz-claudy--opened" : ""}`}}'>
   <button class='coz-claudy-icon' data-claudy-opened='{{opened}}' on:click='toggleClaudy()'/>
-  <ClaudyMenu actions='{{config.actions}}' on:close='toggleClaudy()' usageTracker='{{usageTracker}}' />
+  <ClaudyMenu actions='{{config.actions}}' on:close='toggleClaudy()' usageTracker='{{usageTracker}}' appsList={{appsList}} />
 </div>
 
 <script>

--- a/src/components/ClaudyMenu.svelte
+++ b/src/components/ClaudyMenu.svelte
@@ -84,7 +84,7 @@
               this.selectedActionUrl = ''
               return ''
             }
-            const app = appsList.find(a => a.attributes.slug === action.link.appSlug)
+            const app = appsList.find(a => a.slug === action.link.appSlug)
             if (app && app.links && app.link.related) {
               const appUrl = `${app.links.related}${action.link.path ? action.link.path : ''}`
               this.selectedActionUrl = appUrl

--- a/src/config/claudy.yaml
+++ b/src/config/claudy.yaml
@@ -1,22 +1,22 @@
 actions:
-    - slug: desktop
+    desktop:
       icon: icon-laptop.svg
       link:
         type: external
 
-    - slug: mobile
+    mobile:
       icon: icon-phone.svg
       link:
         type: external
 
-    - slug: cozy-collect
+    cozy-collect:
       icon: icon-bills.svg
       link:
         type: apps
         appSlug: collect
         path: /#/discovery/?intro
 
-    - slug: support
+    support:
       icon: icon-question-mark.svg
       link:
         type: external

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -4,6 +4,7 @@ import deepEqual from 'deep-equal'
 import stack from '../lib/stack'
 
 import MENU_CONFIG from '../config/menu'
+import CLAUDY_CONFIG from '../config/claudy'
 
 const EXCLUDES = ['settings', 'onboarding']
 const CATEGORIES = ['cozy', 'partners', 'ptnb']
@@ -37,6 +38,24 @@ function fetchComingSoonApps () {
       })
 
       return cachedComingSoonApps
+    })
+}
+
+async function getClaudyConfig () {
+  return stack.get.context()
+    .then(context => {
+      const contextActions = context.data && context.data.attributes && context.data.attributes['claudy_actions'] || null
+      if (!contextActions) return null
+      // get an arrays of action
+      const claudyActions = contextActions.map(slug => {
+        if (CLAUDY_CONFIG.actions.hasOwnProperty(slug)) {
+          // adding also the action slug
+          return Object.assign({}, CLAUDY_CONFIG.actions[slug], { slug })
+        }
+      }).filter(action => action)
+      return Object.assign({}, CLAUDY_CONFIG, {
+        actions: claudyActions
+      })
     })
 }
 
@@ -218,4 +237,4 @@ async function updateSettings (config, {storage = true, items = true} = {}) {
   return valve
 }
 
-export { createMenuPointers, updateSettings, updateApps }
+export { createMenuPointers, updateSettings, updateApps, getClaudyConfig }


### PR DESCRIPTION
Here is my example of `cozy.yaml` for the stack:
```yaml
# It is possible to customize some behaviors of cozy-stack in function of the
# context of an instance (the context field of the settings document of this
# instance). Here, the "beta" context is customized with.
contexts:
  beta:
    # Redirect to a specific route of cozy-collect after the onboarding
    onboarded_redirection: collect/#/discovery/?intro
    # Redirect to the photos application after login
    default_redirection: drive/#/files
    # Allow to customize the cozy-bar link to the help
    help_link: https://forum.cozy.io/
    # Coming soon applications listed in the Cozy Bar's app panel
    # Will be removed when the store will be available.
    coming_soon:
      store:
        editor: 'Cozy'
        name: 'Store'
        slug: 'store'
        category: 'cozy'
    # Claudy action slugs list
    claudy_actions:
      - desktop
      - cozy-collect
      - support
```

The actions list order will depend of the slugs list `claudy_actions` order of this context. And if the `claudy_actions` property is missing, no Claudy will be displayed.
Each slug must matched a property of the `actions` object declared in the `./config/claudy.yaml` config file (an unrecognised slug will simply be ignored).

### Documentation
* https://github.com/cozy/cozy-stack/pull/762
* [x] Readme 
* [x] Changelog