### PR TITLE
fix: limit race condition in updateAppsItems :ambulance:

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -98,14 +98,13 @@ async function updateAppsItems (config) {
     apps = [{error: e}]
   }
 
-  config.apps.length = 0
-
   comingSoonApps = await fetchComingSoonApps()
     .catch(error => {
       console.warn && console.warn(`Cozy-bar cannot fetch comming soon apps: ${error.message}`)
       return []
     })
 
+  config.apps.length = 0
   Array.prototype.push.apply(config.apps, apps.concat(comingSoonApps))
 }
 


### PR DESCRIPTION
Why the bug was occurring:

I don't know why, and I did not want to introduce more regression by modifying existing code, but we got a first call to `updateApps` [here](https://github.com/cozy/cozy-bar/blob/master/src/components/Bar.svelte#L73).

I you look closely at [`updateApps`](https://github.com/cozy/cozy-bar/blob/master/src/lib/config.js#L209), it calls `updateAppsItems`, and then this last method directly set the app list into the `config` object (which should be a `state` actually).

So everything is fine except when you click on _Apps_ menu item at an early stage of the page loading. The click fires a second `updateApps`, almost synchronous with the one done above. So now we have a race between this two calls, they will both fetch the app list and update `config.apps`. Even if we should avoid having the same two calls done at the same time, it could be almost transparent if each one reset `config.apps` before setting it.

But since a few commits, we had a call to `fetchComingSoonApps` between the `config.apps.length` reset and the push of the new app list. As the two methods were making the call to `fetchComingSoonApps` simultaneously, they were both adding the app list right after the other method resetted `config.apps.length`.

So, this fix is not really one, it just hides the problem.

The problem is tue to : race condition, side effect into a global `config` object directly updated by functions, multiple calls to the same endpoints at once.

What we need to do to improve this code and avoid this kind a bug in the future :
  * use a `state` object to store the apps, not an assumed immutable `config`
  * cache our results
  * not accessing global state in asynchronous method but use thenable promises instead
  * ensure that our functions are purest as possible