### PR TITLE
fix: header element sizing for long app names

### DIFF
--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -84,7 +84,6 @@ class Bar extends Component {
           <strong>{appName}</strong>
           <sup class='coz-bar-hide-sm coz-bar-beta-status'>{t('beta')}</sup>
         </h1>
-        <hr class='coz-sep-flex' />
         {__TARGET__ !== 'mobile' && !isPublic &&
           <SearchBar />
         }

--- a/src/styles/searchbar.css
+++ b/src/styles/searchbar.css
@@ -1,9 +1,9 @@
 [role=banner] .coz-searchbar{
-  width: 100%;
   height: 100%;
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  flex-grow: 1;
   padding: .3em .8em .3em 2.5em;
   box-sizing: border-box;
 }


### PR DESCRIPTION
Makes the search bar more flexible in terms of sizes, especially useful when the app name is long.