### PR TITLE
chore: define process.env.NODE_ENV to production

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -12,6 +12,7 @@ module.exports = {
       }
     }),
     new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production'), // to compile on production mode (redux)
       __DEVELOPMENT__: false,
       __PIWIK_SITEID__: 8,
       __PIWIK_SITEID_MOBILE__: 12,


### PR DESCRIPTION
Removing warning "You are currently using minified code outside of NODE_ENV === 'production'. This means that you are running a slower development build of Redux."