### PR TITLE
feat: Remove unnecessary space

### DIFF
--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -8,7 +8,6 @@
 @import 'drawer.css'
 @import 'claudy.css'
 @import 'searchbar.css'
-@import 'mobile_app.css'
 @import 'supportModal.css'
 
 @import 'settings/palette'

--- a/src/styles/mobile_app.css
+++ b/src/styles/mobile_app.css
@@ -1,3 +1,0 @@
-[role=banner].coz-target--mobile {
-  padding-left: 1em;
-}


### PR DESCRIPTION
Il y a un bug sur l'application mobile Cozy Bank qui est pour l'instant la seul application mobile à utiliser réellement la cozy-bar. On voit qu'il y a un écart au niveau de l'icone menu en haut à gauche.

Avant | Après
------------ | -------------
![mobile](https://user-images.githubusercontent.com/1135513/32488489-0c54c49e-c3ad-11e7-93f2-322a0bf4b804.png) | ![mobile-fix](https://user-images.githubusercontent.com/1135513/32488766-144fde4e-c3ae-11e7-951d-d9c9ab85d283.png)