### PR TITLE
fix: hide apps button on mobile

### DIFF
--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -93,11 +93,11 @@ class Bar extends Component {
   }
 
   renderLeft () {
-    const { t } = this.props
+    const { t, displayOnMobile, isPublic } = this.props
     // data-tutorial attribute allows to be targeted in an application tutorial
-    return <button className='coz-bar-burger' onClick={this.toggleDrawer} data-icon='icon-apps' data-tutorial='apps-mobile'>
+    return (__TARGET__ !== 'mobile' || displayOnMobile) && !isPublic ? <button className='coz-bar-burger' onClick={this.toggleDrawer} data-icon='icon-apps' data-tutorial='apps-mobile'>
       <span className='coz-bar-hidden'>{t('drawer')}</span>
-    </button>
+    </button> : null
   }
 
   renderRight () {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -111,12 +111,17 @@ const init = ({
   cozyURL = getDefaultStackURL(),
   token = getDefaultToken(),
   replaceTitleOnMobile = false,
-  displayOnMobile = false,
+  displayOnMobile,
   isPublic = false
 } = {}) => {
   // Force public mode in `/public` URLs
   if (/^\/public/.test(window.location.pathname)) {
     isPublic = true
+  }
+
+  if (displayOnMobile === undefined) {
+    displayOnMobile = false
+    if (__TARGET__ === 'mobile') console.warn('Deprecated: cozy-bar option `displayOnMobile` automatically set to `false`, but `true` will be the new default value in the next version. Please explicitly set the option to `false`.')
   }
 
   stack.init({cozyURL, token})


### PR DESCRIPTION
The bar has an option called `displayOnMobile` which is false by default. It used to hide pretty much everything, [including the button to show the other apps](https://github.com/cozy/cozy-bar/blob/a03cd1ab40fb09b8c0fd5a9552e3f77961c650e8/src/components/Bar.jsx#L95-L97).

This changed after dc3a3657fa17d98447eb3339912c946d684da50b , and now this button is always displayed (which is a problem in Drive). I would like to revert to the previous behavior.

That being said, I wonder if this change would cause problems for Cozy Bank?