### PR TITLE
feat: add onLogOut option on init

### DIFF
--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -103,7 +103,7 @@ class Bar extends Component {
   renderRight = () => {
     const { displayOnMobile, isPublic, renewToken } = this.props
     return (__TARGET__ !== 'mobile' || displayOnMobile) && !isPublic
-      ? <Nav toggleSupport={this.toggleSupport} renewToken={renewToken} />
+      ? <Nav toggleSupport={this.toggleSupport} renewToken={renewToken} onLogOut={this.props.onLogOut} />
       : null
   }
 
@@ -117,7 +117,7 @@ class Bar extends Component {
       supportDisplayed,
       usageTracker
     } = this.state
-    const { barLeft, barRight, barCenter, onDrawer, displayOnMobile, isPublic, renewToken } = this.props
+    const { barLeft, barRight, barCenter, onDrawer, displayOnMobile, isPublic, renewToken, onLogOut } = this.props
     return (
       <div className='coz-bar-container'>
         { barLeft || this.renderLeft() }
@@ -133,7 +133,8 @@ class Bar extends Component {
             isClaudyLoading={claudyFired}
             drawerListener={() => onDrawer(this.state.drawerVisible)}
             renewToken={renewToken}
-            toggleSupport={this.toggleSupport} /> : null }
+            toggleSupport={this.toggleSupport}
+            onLogOut={onLogOut} /> : null }
         { claudyEnabled &&
           <Claudy
             usageTracker={usageTracker}

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -30,7 +30,7 @@ class Drawer extends Component {
   }
 
   render () {
-    const { onClaudy, visible, isClaudyLoading, toggleSupport, renewToken } = this.props
+    const { onClaudy, visible, isClaudyLoading, toggleSupport, renewToken, onLogOut } = this.props
     const { settingsData } = this.store
     return (
       <div className='coz-drawer-wrapper'
@@ -46,7 +46,13 @@ class Drawer extends Component {
           <nav className='coz-drawer--settings'>
             {settingsData &&
               <Settings
-                onLogOut={() => this.store.logout()}
+                onLogOut={() => {
+                  if (onLogOut && typeof onLogOut === 'function') {
+                    onLogOut()
+                  } else {
+                    this.store.logout()
+                  }
+                }}
                 settingsData={settingsData}
                 isClaudyLoading={isClaudyLoading}
                 onClaudy={onClaudy}

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -80,7 +80,7 @@ class Nav extends Component {
 
   // data-tutorial attribute allows to be targeted in an application tutorial
   render () {
-    const { t, toggleSupport, renewToken } = this.props
+    const { t, toggleSupport, renewToken, onLogOut } = this.props
     const { apps, settings } = this.state
     const { settingsData } = this.barStore
     return (
@@ -110,7 +110,13 @@ class Nav extends Component {
             <div className='coz-nav-pop coz-nav-pop--settings' id='coz-nav-pop--settings' aria-hidden={!settings.opened}>
               {settingsData &&
                 <Settings
-                  onLogOut={() => this.barStore.logout()}
+                  onLogOut={() => {
+                    if (onLogOut && typeof onLogOut === 'function') {
+                      onLogOut()
+                    } else {
+                      this.barStore.logOut()
+                    }
+                  }}
                   toggleSupport={toggleSupport}
                   settingsData={settingsData}
                 />

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -125,7 +125,8 @@ const init = ({
   replaceTitleOnMobile = false,
   displayOnMobile,
   isPublic = false,
-  renewToken = null
+  renewToken = null,
+  onLogOut
 } = {}) => {
   // Force public mode in `/public` URLs
   if (/^\/public/.test(window.location.pathname)) {
@@ -142,7 +143,8 @@ const init = ({
   if (lang) {
     reduxStore.dispatch(setLocale(lang))
   }
-  return injectBarInDOM({appName, appEditor, iconPath, replaceTitleOnMobile, displayOnMobile, isPublic, renewToken})
+
+  return injectBarInDOM({appName, appEditor, iconPath, replaceTitleOnMobile, displayOnMobile, isPublic, renewToken, onLogOut})
 }
 
 const updateAccessToken = accessToken => {

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -32,6 +32,7 @@ exports[`The bar library should render correctly the cozy-bar 1`] = `
         iconPath=""
         isPublic={false}
         onDrawer={[Function]}
+        onLogOut={undefined}
         renewToken={null}
         replaceTitleOnMobile={false}
       />


### PR DESCRIPTION
In bank, we need to do some custom things when we log out of the mobile app. So we needed to pass an `onLogOut` handler to the cozy-bar. That's the purpose of this PR.