### PR TITLE
feat: debounce search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "core-js": "^2.5.3",
     "cozy-client-js": "^0.3.19",
     "localforage": "^1.5.5",
+    "lodash.debounce": "4.0.8",
     "node-polyglot": "^2.2.2",
     "piwik-react-router": "^0.10.0",
     "preact": "^8.2.7",

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import Autosuggest from 'react-autosuggest'
+import debounce from 'lodash.debounce'
 import { fetchRawIntent } from '../lib/intents'
 
 const INTENT_VERB = 'OPEN'
@@ -95,7 +96,8 @@ class SearchBar extends Component {
           }
         })
 
-        window.addEventListener('message', this.onMessageFromSource(this.sources))
+        const debounced = debounce(this.onMessageFromSource(this.sources), 250, { 'maxWait': 1000 })
+        window.addEventListener('message', debounced)
       })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4006,6 +4006,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"


### PR DESCRIPTION
Put a debounce in the sent message to get search results.
But it appears there is a lot of obscur code in there and in cozy-drive intent.