### PR TITLE
fix: debounce suggestion fetch requests

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -96,9 +96,10 @@ class SearchBar extends Component {
           }
         })
 
-        const debounced = debounce(this.onMessageFromSource(this.sources), 250, { 'maxWait': 1000 })
-        window.addEventListener('message', debounced)
+        window.addEventListener('message', this.onMessageFromSource(this.sources))
       })
+
+    this.debouncedOnSuggestionsFetchRequested = debounce(this.onSuggestionsFetchRequested, 250)
   }
 
   onMessageFromSource = (sources) => (event) => {
@@ -259,7 +260,7 @@ class SearchBar extends Component {
           theme={theme}
           suggestions={suggestionsBySource}
           multiSection
-          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+          onSuggestionsFetchRequested={this.debouncedOnSuggestionsFetchRequested}
           onSuggestionsClearRequested={this.onSuggestionsClearRequested}
           onSuggestionSelected={this.onSuggestionSelected}
           getSuggestionValue={this.getSuggestionValue}


### PR DESCRIPTION
In #180 , we debounced the function that receives the search results. This worked to a degree, but not quite, because sometimes the results come in one after the other with a delay greater than 250ms, and we still get the flashes of results.

Instead, I suggest we debounce the calls to the function that makes the query to the services. So if the user quickly types "hey what's up", we only fetch the suggestions once, when he/she's done typing.

It's still possible to get flashes of course, if you wait just over 250ms and start typing again. But it's less frequent.