### PR TITLE
style: fade search bar on blur

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -243,7 +243,7 @@ class SearchBar extends Component {
     }
 
     const theme = {
-      container: 'coz-searchbar-autosuggest-container' + (searching ? ' --searching' : ''),
+      container: 'coz-searchbar-autosuggest-container' + (searching ? ' --searching' : '') + (focused ? ' --focused' : ''),
       input: 'coz-searchbar-autosuggest-input',
       inputFocused: 'coz-searchbar-autosuggest-input-focused',
       suggestionsContainer: 'coz-searchbar-autosuggest-suggestions-container',

--- a/src/styles/searchbar.css
+++ b/src/styles/searchbar.css
@@ -12,6 +12,11 @@
 [role=banner] .coz-searchbar-autosuggest-container{
   position: relative;
   width: 100%;
+  opacity: .4;
+  transition: all .2s ease-out;
+}
+[role=banner] .coz-searchbar-autosuggest-container.--focused{
+  opacity: 1;
 }
 [role=banner] .coz-searchbar-autosuggest-container:before{
   content: '';


### PR DESCRIPTION
Minor style update: when the searchbar isn't focused, we reduce it's opacity.