### PR TITLE
Use app name_prefix instead of app editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ Once you have the library included in your application, starts by intialize it i
 ```js
 window.cozy.bar.init({
   appName: MY_APP_NAME,
-  appEditor: APP_EDITOR
+  appNamePrefix: MY_APP_NAME_PREFIX
   iconPath: PATH_TO_SVG_ICON,
   lang: LOCALE
 })
 ```
 
-`appName` param in hash is mandatory when `appEditor`, `lang` and `iconPath` are optionals. If not passed, their values are detected into the DOM:
+`appName` param in hash is mandatory when `appNamePrefix`, `lang` and `iconPath` are optionals. If not passed, their values are detected into the DOM:
 
-- `appEditor` is extracted from the manifest. Originally used for apps maintained by Cozy Cloud teams.
+- `appNamePrefix` is extracted from the manifest. Originally used for apps maintained by Cozy Cloud teams.
 - `lang` is extracted from the `lang` attribute of the `<html>` tag. Defaults to 'en'
 - `iconPath` uses the favicon 32px. Defaults to a blank GIF
 

--- a/src/components/AppsList.jsx
+++ b/src/components/AppsList.jsx
@@ -84,7 +84,7 @@ class AppsList extends Component {
                   ? app.icon.src
                   : require('../assets/icons/16/icon-cube-16.svg')
                 const blurry = !app.icon || !app.icon.cached
-                const label = (app.editor ? (app.editor + ' ') : '') + app.name
+                const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
                 return <AppIcon
                   label={label}
                   href={app.href}

--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -91,11 +91,11 @@ class Bar extends Component {
   }
 
   renderCenter () {
-    const { appName, appEditor, iconPath, replaceTitleOnMobile, lang } = this.props
+    const { appName, appNamePrefix, iconPath, replaceTitleOnMobile, lang } = this.props
     return (
       <h1 lang={lang} className={`coz-bar-title ${replaceTitleOnMobile ? 'coz-bar-hide-sm' : ''}`}>
         <img className='coz-bar-hide-sm' src={iconPath} width='32' />
-        {appEditor && <span className='coz-bar-hide-sm'>{appEditor}</span>}
+        {appNamePrefix && <span className='coz-bar-hide-sm'>{appNamePrefix}</span>}
         <strong>{appName}</strong>
       </h1>
     )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -106,11 +106,6 @@ const getDefaultToken = () => {
   return appNode.dataset.cozyToken
 }
 
-const getEditor = () => {
-  const appNode = document.querySelector(APP_SELECTOR)
-  return appNode.dataset.cozyAppEditor || appNode.dataset.cozyEditor || undefined
-}
-
 const getDefaultIcon = () => {
   const linkNode = document.querySelector('link[rel="icon"][sizes^="32"]')
   if (linkNode !== null) {
@@ -118,6 +113,11 @@ const getDefaultIcon = () => {
   } else {
     return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
   }
+}
+
+const getAppNamePrefix = () => {
+  const appNode = document.querySelector(APP_SELECTOR)
+  return appNode.dataset.cozyAppNamePrefix || undefined
 }
 
 const getUserActionRequired = () => {
@@ -134,7 +134,7 @@ const getUserActionRequired = () => {
 
 const init = ({
   appName,
-  appEditor = getEditor(),
+  appNamePrefix = getAppNamePrefix(),
   lang,
   iconPath = getDefaultIcon(),
   cozyURL = getDefaultStackURL(),
@@ -155,7 +155,7 @@ const init = ({
     if (__TARGET__ === 'mobile') console.warn('Deprecated: cozy-bar option `displayOnMobile` automatically set to `false`, but `true` will be the new default value in the next version. Please explicitly set the option to `false`.')
   }
 
-  reduxStore.dispatch(setInfos(appName, appEditor))
+  reduxStore.dispatch(setInfos(appName, appNamePrefix))
   stack.init({cozyURL, token})
   if (lang) {
     reduxStore.dispatch(setLocale(lang))
@@ -163,7 +163,7 @@ const init = ({
 
   return injectBarInDOM({
     appName,
-    appEditor,
+    appNamePrefix,
     iconPath,
     replaceTitleOnMobile,
     displayOnMobile,

--- a/src/lib/reducers/apps.js
+++ b/src/lib/reducers/apps.js
@@ -18,16 +18,16 @@ export const getApps = state => {
 
   if (!state.apps || !state.apps.data) return []
   return state.apps.data.filter(app =>
-    (app.name !== state.appName || app.editor !== state.editor) && !app.comingSoon
+    (app.name !== state.appName || app.name_prefix !== state.appNamePrefix) && !app.comingSoon
   )
 }
 export const isAppListForbidden = state => state.apps ? state.apps.forbidden : false
-export const getCurrentApp = state => `${state.editor} ${state.appName}`
+export const getCurrentApp = state => `${state.appNamePrefix} ${state.appName}`
 
 // actions
 const receiveAppList = apps => ({ type: RECEIVE_APP_LIST, apps })
 const receiveAppListForbidden = () => ({ type: RECEIVE_APP_LIST_FORBIDDEN })
-export const setInfos = (appName, editor) => ({ type: SET_INFOS, appName, editor })
+export const setInfos = (appName, appNamePrefix) => ({ type: SET_INFOS, appName, appNamePrefix })
 
 const _getCategory = (manifest) => {
   if (!manifest.categories && manifest.category && CATEGORIES.includes(manifest.category)) {
@@ -49,7 +49,7 @@ export const fetchApps = () => async dispatch => {
     // TODO load only one time icons
     const icons = await Promise.all(apps.map(app => stack.get.icon(app.links.icon)))
     const appsWithIcons = apps.map((app, idx) => ({
-      editor: app.attributes.editor,
+      namePrefix: app.attributes.name_prefix,
       name: app.attributes.name,
       slug: app.attributes.slug,
       href: app.links.related,
@@ -114,7 +114,7 @@ const fetchComingSoonApps = () => {
 const defaultState = {
   apps: { data: null, forbidden: false },
   appName: null,
-  editor: null
+  appNamePrefix: null
 }
 
 const reducer = (state = defaultState, action) => {
@@ -124,7 +124,7 @@ const reducer = (state = defaultState, action) => {
     case RECEIVE_APP_LIST_FORBIDDEN:
       return { ...state, apps: { ...state.apps, forbidden: true } }
     case SET_INFOS:
-      return { ...state, appName: action.appName, editor: action.editor }
+      return { ...state, appName: action.appName, appNamePrefix: action.appNamePrefix }
     default:
       return state
   }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -26,8 +26,8 @@ exports[`The bar library should render correctly the cozy-bar 1`] = `
       dictRequire={[Function]}
     >
       <Wrapper
-        appEditor="cozy"
         appName="test-app"
+        appNamePrefix="cozy"
         displayOnMobile={true}
         iconPath=""
         isPublic={false}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,7 +13,7 @@ describe('The bar library', function () {
       '</div>'
     const options = {
       appName: 'test-app',
-      appEditor: 'cozy',
+      appNamePrefix: 'cozy',
       lang: 'en',
       iconPath: '',
       cozyURL: 'https://mock.cozy',


### PR DESCRIPTION
We don't use the editor as application name prefix anymore but a dedicated property.
(this property is already used in `cozy-store`)