### PR TITLE
fix z-index of menu on ios

### DIFF
--- a/src/styles/bar.css
+++ b/src/styles/bar.css
@@ -28,13 +28,6 @@
   [role=banner] .coz-bar-container {
     padding: 0 1em 0 0;
   }
-
-  [role=banner][data-drawer-visible=true] {
-    /* Force the BAR to be above selection bar in mobile mode,
-     * only when drawer is opened
-     */
-    z-index: var(--z-index-over-selection);
-  }
 }
 
 [role=banner] .coz-bar-title {


### PR DESCRIPTION
## Bug

A CSS ordering bug causes the nav-bar to be above the drawer menu on iOS.

<img src=https://user-images.githubusercontent.com/465582/40307453-e4295dc8-5d02-11e8-9182-b3e72f7f2db0.png width=50%/>

Normally (on browsers) the bar when drawer is opened has a z-index of 90 but on iOS it is 31 because the rule is loaded after.
Since the rule with 31 is normally overrided and is causing the bug, I deleted it.

Ordering bug : 

on iOS (31 after 90 and 90 is discarded) : 

<img src='https://user-images.githubusercontent.com/465582/40307393-8e833eca-5d02-11e8-8664-10b87713f420.png' width=50% />

on other browsers (90 after 31 and 31 is discarded) : 

<img src=https://user-images.githubusercontent.com/465582/40307409-a5cf314c-5d02-11e8-936b-536235cda8bd.png width=50% />
