### PR TITLE
fix: Better JSON handling

### DIFF
--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -17,7 +17,8 @@ function fetchOptions () {
   return {
     credentials: 'include',
     headers: {
-      Authorization: `Bearer ${COZY_TOKEN}`
+      Authorization: `Bearer ${COZY_TOKEN}`,
+      Accept: 'application/json'
     }
   }
 }
@@ -35,7 +36,10 @@ const errorStatuses = {
 
 function getApps () {
   return fetchJSON(`${COZY_URL}/apps/`, fetchOptions())
-    .then(json => json.data)
+    .then(json => {
+      if (json.error) throw new Error(json.error)
+      else return json.data
+    })
 }
 
 function fetchJSON (url, options) {


### PR DESCRIPTION
A minor thing, but:

- The requests on the stack had no `content-type` header, so the stack can answer whatever it wants. It uses json most of the time, but for errors for example, it sometimes use plain text unless you tell it not to.
- When there's an error, there's no `data` in the JSON, so I made sure we get the actual error instead of some random runtime error.