### PR TITLE
refactor: AppIcon

### DIFF
--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -37,7 +37,7 @@ class AppIcon extends React.Component {
     const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
     const comingSoon = app.comingSoon || false
     const iconSrc = app.icon && app.icon.cached ? app.icon.src : defaultIcon
-    const canShowComingSoonDescription = HAS_COMING_SOON_DESCRIPTION[app.slug]
+    const canShowComingSoonDescription = HAS_COMING_SOON_DESCRIPTION.hasOwnProperty(app.slug)
 
     let appClass = comingSoon ? 'coz-bar-coming-soon-app' : ''
     let onClick = canShowComingSoonDescription ? this.openComingSoon : null

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -2,39 +2,43 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import defaultIcon from '../assets/icons/16/icon-cube-16.svg'
 
-export const AppIcon = ({ t, onClick, app }) => {
-  const dataIcon = app.icon ? `icon-${app.slug}` : ''
-  const blurry = !app.icon || !app.icon.cached || false
-  const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
-  const comingSoon = app.comingSoon || false
-  const iconSrc = app.icon && app.icon.cached ? app.icon.src : defaultIcon
+class AppIcon extends React.Component {
+  render () {
+    const { t, app } = this.props
+    const dataIcon = app.icon ? `icon-${app.slug}` : ''
+    const blurry = !app.icon || !app.icon.cached || false
+    const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
+    const comingSoon = app.comingSoon || false
+    const iconSrc = app.icon && app.icon.cached ? app.icon.src : defaultIcon
 
-  let appClass = comingSoon ? 'coz-bar-coming-soon-app' : ''
+    let appClass = comingSoon ? 'coz-bar-coming-soon-app' : ''
 
-  let href = app.href
-  if (href) onClick = null // href always have priority
-  if (onClick) {
-    appClass += ' --toggable'
-    href = '#'
+    let href = app.href
+    let onClick = this.props
+    if (href) onClick = null // href always have priority
+    if (onClick) {
+      appClass += ' --toggable'
+      href = '#'
+    }
+
+    return (
+      <li className='coz-nav-item'>
+        <a role='menuitem' href={href} data-icon={dataIcon} className={appClass} title={label} onClick={onClick}>
+          {iconSrc &&
+            <img src={iconSrc} alt='' width='64' height='64' className={blurry && 'blurry'} />
+          }
+          {comingSoon &&
+            <span
+              className='coz-bar-coming-soon-badge'
+            >
+              {t('soon')}
+            </span>
+          }
+          <p className='coz-label'>{label}</p>
+        </a>
+      </li>
+    )
   }
-
-  return (
-    <li className='coz-nav-item'>
-      <a role='menuitem' href={href} data-icon={dataIcon} className={appClass} title={label} onClick={onClick}>
-        {iconSrc &&
-          <img src={iconSrc} alt='' width='64' height='64' className={blurry && 'blurry'} />
-        }
-        {comingSoon &&
-          <span
-            className='coz-bar-coming-soon-badge'
-          >
-            {t('soon')}
-          </span>
-        }
-        <p className='coz-label'>{label}</p>
-      </a>
-    </li>
-  )
 }
 
 export default translate()(AppIcon)

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import defaultIcon from '../assets/icons/16/icon-cube-16.svg'
 import ComingSoonModal from 'components/ComingSoonModal'
+import { appShape } from '../proptypes'
 
 const HAS_COMING_SOON_DESCRIPTION = {
   store: true
@@ -71,6 +72,10 @@ class AppIcon extends React.Component {
       </li>
     )
   }
+}
+
+AppIcon.propTypes = {
+  app: appShape.isRequired
 }
 
 export default translate()(AppIcon)

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -1,16 +1,26 @@
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
+import defaultIcon from '../assets/icons/16/icon-cube-16.svg'
 
-export const AppIcon = ({ t, label, dataIcon, iconSrc, href, comingSoon = false, blurry = false, toggle }) => {
-  if (href) toggle = null // href always have priority
+export const AppIcon = ({ t, onClick, app }) => {
+  const dataIcon = app.icon ? `icon-${app.slug}` : ''
+  const blurry = !app.icon || !app.icon.cached || false
+  const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
+  const comingSoon = app.comingSoon || false
+  const iconSrc = app.icon && app.icon.cached ? app.icon.src : defaultIcon
+
   let appClass = comingSoon ? 'coz-bar-coming-soon-app' : ''
-  if (toggle) {
+
+  let href = app.href
+  if (href) onClick = null // href always have priority
+  if (onClick) {
     appClass += ' --toggable'
     href = '#'
   }
+
   return (
     <li className='coz-nav-item'>
-      <a role='menuitem' href={href} data-icon={dataIcon} className={appClass} title={label} onClick={toggle}>
+      <a role='menuitem' href={href} data-icon={dataIcon} className={appClass} title={label} onClick={onClick}>
         {iconSrc &&
           <img src={iconSrc} alt='' width='64' height='64' className={blurry && 'blurry'} />
         }

--- a/src/components/AppIcon.jsx
+++ b/src/components/AppIcon.jsx
@@ -1,8 +1,34 @@
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import defaultIcon from '../assets/icons/16/icon-cube-16.svg'
+import ComingSoonModal from 'components/ComingSoonModal'
+
+const HAS_COMING_SOON_DESCRIPTION = {
+  store: true
+}
 
 class AppIcon extends React.Component {
+  state = {
+    showingComingSoon: false
+  }
+
+  toggleComingSoon = (showing) => {
+    this.setState({
+      showingComingSoon: showing
+    })
+  }
+
+  openComingSoon = (ev) => {
+    this.toggleComingSoon(true)
+    if (ev) {
+      ev.preventDefault()
+    }
+  }
+
+  closeComingSoon = () => {
+    this.toggleComingSoon(false)
+  }
+
   render () {
     const { t, app } = this.props
     const dataIcon = app.icon ? `icon-${app.slug}` : ''
@@ -10,11 +36,12 @@ class AppIcon extends React.Component {
     const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
     const comingSoon = app.comingSoon || false
     const iconSrc = app.icon && app.icon.cached ? app.icon.src : defaultIcon
+    const canShowComingSoonDescription = HAS_COMING_SOON_DESCRIPTION[app.slug]
 
     let appClass = comingSoon ? 'coz-bar-coming-soon-app' : ''
+    let onClick = canShowComingSoonDescription ? this.openComingSoon : null
 
     let href = app.href
-    let onClick = this.props
     if (href) onClick = null // href always have priority
     if (onClick) {
       appClass += ' --toggable'
@@ -36,6 +63,11 @@ class AppIcon extends React.Component {
           }
           <p className='coz-label'>{label}</p>
         </a>
+        { this.state.showingComingSoon &&
+          <ComingSoonModal
+            onClose={this.closeComingSoon}
+            appSlug={app.slug}
+          /> }
       </li>
     )
   }

--- a/src/components/AppIcon.spec.jsx
+++ b/src/components/AppIcon.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import AppIcon from './AppIcon'
+import { shallow } from 'enzyme'
+
+describe('app icon', () => {
+  let spyConsoleError
+  beforeEach(() => {
+    spyConsoleError = jest.spyOn(console, 'error')
+    spyConsoleError.mockImplementation(message => {
+      if (message.lastIndexOf('Warning: Failed prop type:') === 0) {
+        throw new Error(message)
+      }
+    })
+  })
+
+  afterEach(() => {
+    spyConsoleError.mockRestore()
+  })
+
+  it('should render correctly', () => {
+    const app = {
+      slug: 'cozy-drive',
+      name: 'Drive'
+    }
+    const root = shallow(<AppIcon app={app} />)
+    expect(root).toMatchSnapshot()
+  })
+})

--- a/src/components/AppsList.jsx
+++ b/src/components/AppsList.jsx
@@ -10,7 +10,9 @@ import AppIconGroup from './AppIconGroup'
 import AppIcon from './AppIcon'
 import FakeAppsList from './FakeAppsList'
 
-const COMING_SOON_WITH_DESCRIPTION = ['store']
+const COMING_SOON_WITH_DESCRIPTION = {
+  store: true
+}
 
 // TODO Add errors
 class AppsList extends Component {
@@ -79,24 +81,13 @@ class AppsList extends Component {
           return (
             <AppIconGroup category={`Categories.${category.slug}`} wrapping={wrapping}>
               {category.items && category.items.map(app => {
-                const dataIcon = app.icon ? `icon-${app.slug}` : ''
-                const iconSrc = app.icon && app.icon.cached
-                  ? app.icon.src
-                  : require('../assets/icons/16/icon-cube-16.svg')
-                const blurry = !app.icon || !app.icon.cached
-                const label = (app.namePrefix ? (app.namePrefix + ' ') : '') + app.name
+                const canShowComingSoonDescription = COMING_SOON_WITH_DESCRIPTION[app.slug]
                 return <AppIcon
-                  label={label}
-                  href={app.href}
-                  dataIcon={dataIcon}
-                  comingSoon={app.comingSoon}
-                  toggle={
-                    COMING_SOON_WITH_DESCRIPTION.includes(app.slug)
-                      ? () => toggleComingSoon(app.slug)
-                      : false
-                  }
-                  iconSrc={iconSrc}
-                  blurry={blurry} />
+                  app={app}
+                  onClick={
+                    canShowComingSoonDescription ? () =>
+                      toggleComingSoon(app.slug) : null
+                  } />
               })}
             </AppIconGroup>
           )

--- a/src/components/AppsList.jsx
+++ b/src/components/AppsList.jsx
@@ -10,10 +10,6 @@ import AppIconGroup from './AppIconGroup'
 import AppIcon from './AppIcon'
 import FakeAppsList from './FakeAppsList'
 
-const COMING_SOON_WITH_DESCRIPTION = {
-  store: true
-}
-
 // TODO Add errors
 class AppsList extends Component {
   // Take an items array and return an array of category objects with the matching category slug and items
@@ -56,7 +52,7 @@ class AppsList extends Component {
   }
 
   render () {
-    const { t, wrappingLimit, toggleComingSoon } = this.props
+    const { t, wrappingLimit } = this.props
     const categories = this.getCategorizedApps()
 
     /*
@@ -81,13 +77,7 @@ class AppsList extends Component {
           return (
             <AppIconGroup category={`Categories.${category.slug}`} wrapping={wrapping}>
               {category.items && category.items.map(app => {
-                const canShowComingSoonDescription = COMING_SOON_WITH_DESCRIPTION[app.slug]
-                return <AppIcon
-                  app={app}
-                  onClick={
-                    canShowComingSoonDescription ? () =>
-                      toggleComingSoon(app.slug) : null
-                  } />
+                return <AppIcon app={app} />
               })}
             </AppIconGroup>
           )

--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -14,7 +14,6 @@ import Nav from 'components/Nav'
 import SearchBar from 'components/SearchBar'
 import Claudy from 'components/Claudy'
 import SupportModal from 'components/SupportModal'
-import ComingSoonModal from 'components/ComingSoonModal'
 import { getContent, getCurrentApp } from 'lib/reducers'
 
 class Bar extends Component {
@@ -28,7 +27,6 @@ class Bar extends Component {
       drawerVisible: false,
       usageTracker: null,
       supportDisplayed: false,
-      comingSoonToDisplay: null,
       searchBarEnabled: props.currentApp === 'Cozy Drive' && !props.isPublic
     }
   }
@@ -84,12 +82,6 @@ class Bar extends Component {
     this.setState({supportDisplayed: !supportDisplayed})
   }
 
-  toggleComingSoon = (slug) => {
-    this.setState((state, props) => ({
-      comingSoonToDisplay: state.comingSoonToDisplay ? null : slug
-    }))
-  }
-
   renderCenter () {
     const { appName, appNamePrefix, iconPath, replaceTitleOnMobile, lang } = this.props
     return (
@@ -114,7 +106,6 @@ class Bar extends Component {
     return (__TARGET__ !== 'mobile' || displayOnMobile) && !isPublic
       ? <Nav
         toggleSupport={this.toggleSupport}
-        toggleComingSoon={this.toggleComingSoon}
         renewToken={renewToken}
         onLogOut={this.props.onLogOut}
       />
@@ -129,7 +120,6 @@ class Bar extends Component {
       drawerVisible,
       searchBarEnabled,
       supportDisplayed,
-      comingSoonToDisplay,
       usageTracker
     } = this.state
     const { barLeft, barRight, barCenter, onDrawer, displayOnMobile, isPublic, renewToken, onLogOut, userActionRequired } = this.props
@@ -150,7 +140,6 @@ class Bar extends Component {
               drawerListener={() => onDrawer(this.state.drawerVisible)}
               renewToken={renewToken}
               toggleSupport={this.toggleSupport}
-              toggleComingSoon={this.toggleComingSoon}
               onLogOut={onLogOut} /> : null }
           { claudyEnabled &&
             <Claudy
@@ -161,11 +150,7 @@ class Bar extends Component {
             /> }
           { supportDisplayed &&
             <SupportModal onClose={this.toggleSupport} /> }
-          { comingSoonToDisplay &&
-            <ComingSoonModal
-              onClose={this.toggleComingSoon}
-              appSlug={comingSoonToDisplay}
-            /> }
+
         </div>
         {userActionRequired &&
           <Banner {...userActionRequired} />

--- a/src/components/ComingSoonModal.jsx
+++ b/src/components/ComingSoonModal.jsx
@@ -9,6 +9,7 @@ class ComingSoonModal extends Component {
     return (
       <div>
         <Modal
+          into='body'
           dismissAction={this.props.onClose}
           className='coz-coming-soon-modal'
         >

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -147,7 +147,7 @@ class Drawer extends Component {
   }
 
   render () {
-    const { onClaudy, visible, isClaudyLoading, toggleSupport, renewToken, onLogOut, toggleComingSoon, showSpinner } = this.props
+    const { onClaudy, visible, isClaudyLoading, toggleSupport, renewToken, onLogOut, showSpinner } = this.props
     const { settingsData } = this.store
     return (
       <div className='coz-drawer-wrapper'
@@ -165,7 +165,6 @@ class Drawer extends Component {
                 <AppsList
                   wrappingLimit={3}
                   renewToken={renewToken}
-                  toggleComingSoon={toggleComingSoon}
                 />
               )
             }

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -83,7 +83,7 @@ class Nav extends Component {
 
   // data-tutorial attribute allows to be targeted in an application tutorial
   render () {
-    const { t, toggleSupport, renewToken, onLogOut, toggleComingSoon } = this.props
+    const { t, toggleSupport, renewToken, onLogOut } = this.props
     const { apps, settings } = this.state
     const { settingsData } = this.barStore
     return (
@@ -102,7 +102,6 @@ class Nav extends Component {
               <AppsList
                 wrappingLimit={4}
                 renewToken={renewToken}
-                toggleComingSoon={toggleComingSoon}
               />
             </div>
           </li>

--- a/src/components/__snapshots__/AppIcon.spec.jsx.snap
+++ b/src/components/__snapshots__/AppIcon.spec.jsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app icon should render correctly 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Wrapper
+    app={
+      Object {
+        "name": "Drive",
+        "slug": "cozy-drive",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "app": Object {
+        "name": "Drive",
+        "slug": "cozy-drive",
+      },
+      "f": undefined,
+      "lang": undefined,
+      "t": undefined,
+    },
+    "ref": null,
+    "rendered": null,
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "app": Object {
+          "name": "Drive",
+          "slug": "cozy-drive",
+        },
+        "f": undefined,
+        "lang": undefined,
+        "t": undefined,
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/proptypes.js
+++ b/src/proptypes.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types'
+
+export const appShape = PropTypes.shape({
+  icon: PropTypes.shape({
+    cached: PropTypes.object,
+    src: PropTypes.string
+  }),
+  slug: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  namePrefix: PropTypes.string,
+  comingSoon: PropTypes.bool,
+  href: PropTypes.string
+})

--- a/test/jestLib/setup.js
+++ b/test/jestLib/setup.js
@@ -1,7 +1,12 @@
-require('babel-polyfill')
+import Enzyme from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+import 'babel-polyfill'
 
 // polyfill for requestAnimationFrame
 /* istanbul ignore next */
 global.requestAnimationFrame = (cb) => {
   setTimeout(cb, 0)
 }
+
+Enzyme.configure({ adapter: new Adapter() })

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -1,12 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 
 import createStore from 'lib/store'
 import api from 'lib/api'
 import { getContent as _getContent } from 'lib/reducers'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 const store = createStore()
 const {


### PR DESCRIPTION
In preparation for another PR, I've refactored the `AppIcon` code.

* `AppIcon` understands directly the `app` object

The AppList had 6 props related to the `app` object. The `AppList`
had to know all this properties, and forced the creation of useless
props on the `AppIcon`.

[Components/functions should know as little as possible of each other
API][Demeter].

Now the `AppList` [only responsibility][responsibility] is simply to render a list of `AppIcons`.
The `AppIcon` responsibility is to render the `Icon` and text directly from
the `app` object.


* Threading of the `toggleComingSoon`

The `toggleComingSoon` prop was passed from component to component since
the state of the modal was stored in the `Bar` state. It forced every component
in the middle to know about this function that they did not care about.

Putting the `ComingSoonModal` inside the `AppIcon` allows to remove this
unnecessary threading. To bypass the fact that the Modal would be rendered
inside the `Drawer` window, I added `into='body'` which renders the modal
into the `Body`.

* Added tests

[Demeter]:  https://fr.wikipedia.org/wiki/Loi_de_D%C3%A9m%C3%A9ter
[responsibility]: https://fr.wikipedia.org/wiki/Principe_de_responsabilit%C3%A9_unique
