### PR TITLE
Do not merge: Change cozy-collect action to gather action

### DIFF
--- a/src/config/claudyActions.yaml
+++ b/src/config/claudyActions.yaml
@@ -8,12 +8,12 @@ mobile:
   link:
     type: external
 
-cozy-collect:
+gather:
   icon: icon-bills.svg
   link:
     type: apps
-    appSlug: collect
-    path: '#/discovery/?intro'
+    appSlug: home
+    path: '/intro'
 
 support:
   icon: icon-question-mark.svg


### PR DESCRIPTION
**Do not merge until Cozy-Collect has been removed from all Cozy instances.**

Following the rebranding of Cozy-Collect to Cozy-Home, update the `cozy-collect` action to `gather`.