### PR TITLE
Remove cozy-collect action

### DIFF
--- a/src/config/claudyActions.yaml
+++ b/src/config/claudyActions.yaml
@@ -8,13 +8,6 @@ mobile:
   link:
     type: external
 
-cozy-collect:
-  icon: icon-bills.svg
-  link:
-    type: apps
-    appSlug: collect
-    path: '#/discovery/?intro'
-
 support:
   icon: icon-question-mark.svg
   link:


### PR DESCRIPTION
While migrating from Cozy-Collect to Cozy-Home, we are temporarly removing the Claudy `cozy-collect` action to avoid keeping both Cozy-Collect and Cozy-Home too long on registry.