### PR TITLE
Use webpack module/related paths

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.json', '.yaml'],
-    modules: ['node_modules', SRC_DIR]
+    modules: [path.join(__dirname, '../node_modules'), SRC_DIR]
   },
   devtool: '#source-map',
   module: {

--- a/config/webpack.config.extract.js
+++ b/config/webpack.config.extract.js
@@ -3,6 +3,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const { filename } = require('./webpack.vars.js')
 const webpack = require('webpack')
+const path = require('path')
 
 module.exports = {
   resolve: {
@@ -21,7 +22,12 @@ module.exports = {
           },
           {
             loader: 'postcss-loader',
-            options: { sourceMap: true }
+            options: {
+              config: {
+                path: path.join(__dirname, '../postcss.config.js')
+              },
+              sourceMap: true
+            }
           },
           {
             loader: 'stylus-loader'
@@ -44,7 +50,12 @@ module.exports = {
           },
           {
             loader: 'postcss-loader',
-            options: { sourceMap: true }
+            options: {
+              config: {
+                path: path.join(__dirname, '../postcss.config.js')
+              },
+              sourceMap: true
+            }
           },
           {
             loader: 'stylus-loader'

--- a/config/webpack.config.inline-styles.js
+++ b/config/webpack.config.inline-styles.js
@@ -20,7 +20,12 @@ module.exports = {
         },
         {
           loader: 'postcss-loader',
-          options: { sourceMap: true }
+          options: {
+            config: {
+              path: path.join(__dirname, '../postcss.config.js')
+            },
+            sourceMap: true
+          }
         },
         {
           loader: 'stylus-loader'

--- a/src/components/Apps/AppsContent.jsx
+++ b/src/components/Apps/AppsContent.jsx
@@ -6,7 +6,7 @@ import { ButtonLink } from 'cozy-ui/react/Button'
 import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
 import { getApps, fetchApps, getHomeApp } from 'lib/reducers'
 
-import AppItem from './AppItem'
+import AppItem from 'components/Apps/AppItem'
 import cozyIcon from 'assets/icons/16/icon-cozy-16.svg'
 
 class AppsContent extends Component {

--- a/src/components/Apps/index.jsx
+++ b/src/components/Apps/index.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux'
 
 import { fetchApps } from 'lib/reducers'
 
-import AppsContent from './AppsContent'
-import AppNavButtons from './AppNavButtons'
+import AppsContent from 'components/Apps/AppsContent'
+import AppNavButtons from 'components/Apps/AppNavButtons'
 
 const BUSY_DELAY = 450
 

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -3,10 +3,10 @@ import { connect } from 'react-redux'
 import Hammer from 'hammerjs'
 import Spinner from 'cozy-ui/react/Spinner'
 
-import { fetchApps, isAppListFetching, hasFetched } from '../lib/reducers'
+import { fetchApps, isAppListFetching, hasFetched } from 'lib/reducers'
 
-import AppsContent from './Apps/AppsContent'
-import SettingsContent from './Settings/SettingsContent'
+import AppsContent from 'components/Apps/AppsContent'
+import SettingsContent from 'components/Settings/SettingsContent'
 
 class Drawer extends Component {
   constructor (props, context) {

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import Autosuggest from 'react-autosuggest'
 import debounce from 'lodash.debounce'
-import { fetchRawIntent } from '../lib/intents'
+import { fetchRawIntent } from 'lib/intents'
 
 const INTENT_VERB = 'OPEN'
 const INTENT_DOCTYPE = 'io.cozy.suggestions'

--- a/src/components/Settings/SettingsContent.jsx
+++ b/src/components/Settings/SettingsContent.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { translate } from 'cozy-ui/react/I18n'
 
-import StorageData from './StorageData'
+import StorageData from 'components/Settings/StorageData'
 
 const Settings = ({ t, onLogOut, settingsData, onClaudy, isDrawer = false, isClaudyLoading, toggleSupport }) => (
   <div className='coz-nav-pop-content'>

--- a/src/components/Settings/index.jsx
+++ b/src/components/Settings/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 
 import { translate } from 'cozy-ui/react/I18n'
 
-import SettingsContent from './SettingsContent'
+import SettingsContent from 'components/Settings/SettingsContent'
 
 const BUSY_DELAY = 450
 


### PR DESCRIPTION
To prepare the bar for customization, this PR :
* Use relative paths for Webpack options and loader options
* Use relative paths to `src/` for all `import` statements