### PR TITLE
Fix realtime  initialization

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -174,7 +174,9 @@ const init = async ({
   }
 
   const realtimeConfig = {
-    url: cozyURL,
+    // It's too weid to generate a fake URL here. We should just pass
+    // domain, token and a secure boolean to initialize realtime.
+    url: `${window.location.protocol}//${cozyURL}`,
     token: token
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,7 +5,7 @@ import Adapter from 'enzyme-adapter-react-16'
 Enzyme.configure({ adapter: new Adapter() })
 
 describe('The bar library', function () {
-  test.skip('should render correctly the cozy-bar', () => {
+  xit('should render correctly the cozy-bar', () => {
     // Set up our document body
     document.body.innerHTML =
       '<div role="application">' +


### PR DESCRIPTION
Realtime need an URL, so we generate one which mean nothing.

Realtime should be able to handle `domain` and `secure` parameters, see https://github.com/cozy/cozy-libs/pull/21