### PR TITLE
Better realtime

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,6 @@ import React from 'react'
 import { render } from 'react-dom'
 
 import I18n from 'cozy-ui/react/I18n'
-import realtime from 'cozy-realtime'
 import stack from './lib/stack'
 import {
   deleteApp,
@@ -198,34 +197,6 @@ const init = async ({
   })
   if (lang) {
     reduxStore.dispatch(setLocale(lang))
-  }
-
-  const realtimeConfig = {
-    // It's too weid to generate a fake URL here. We should just pass
-    // domain, token and a secure boolean to initialize realtime.
-    url: `${window.location.protocol}//${cozyURL}`,
-    token: token
-  }
-
-  try {
-    const realtimeApps = await realtime.subscribeAll(
-      realtimeConfig,
-      'io.cozy.apps'
-    )
-
-    realtimeApps.onCreate(async app => {
-      // Fetch direclty the app to get attributes `related` as well.
-      let fullApp
-      try {
-        fullApp = await stack.get.app(app.slug)
-      } catch (error) {
-        throw new Error(`Cannont fetch app ${app.slug}: ${error.message}`)
-      }
-      reduxStore.dispatch(receiveApp(fullApp))
-    })
-    realtimeApps.onDelete(app => reduxStore.dispatch(deleteApp(app)))
-  } catch (error) {
-    console.warn(`Cannot initialize realtime in Cozy-bar: ${error.message}`)
   }
 
   return injectBarInDOM({


### PR DESCRIPTION
This PR makes the realtime handle correctly the cozyURL parameter passed by mobile apps.

Also, it adds a new ssl parameter which can be used to force secure protocols used by the bar. Ideally, apps will soon be able to pass this parameter, based on their environment. See [this PR on cozy-scripts](https://github.com/CPatchane/create-cozy-app/pull/810/)