### PR TITLE
Disable redux-persist for apps

### DIFF
--- a/src/lib/store/index.js
+++ b/src/lib/store/index.js
@@ -7,7 +7,7 @@ import storage from 'redux-persist/lib/storage'
 const config = {
   storage,
   key: 'cozy-bar',
-  whitelist: ['locale', 'apps']
+  whitelist: ['locale']
 }
 
 const reducer = persistCombineReducers(config, { ...reducers })


### PR DESCRIPTION
Temporary removing of this feature to avoid 'infinite fetching' state stored in localStorage