### PR TITLE
Fix SVG icons for cordova and iOS10 📱

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -100,7 +100,7 @@ export class AppItem extends React.Component {
             <AppIcon
               app={app}
               className="coz-nav-apps-item-icon"
-              fetchIcon={stack.get.icon}
+              fetchIcon={() => stack.get.icon(app, true)}
               key={app.slug}
             />
           )}

--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -114,29 +114,72 @@ function getApp(slug) {
   })
 }
 
-async function getIcon(url, useCache = true) {
+const cache = {}
+
+const mimeTypes = {
+  gif: 'image/gif',
+  ico: 'image/vnd.microsoft.icon',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml'
+}
+
+async function getIcon(app = {}, useCache = true) {
   if (useCache && cache.icons && cache.icons[url]) return cache.icons[url]
 
+  const url = app.links && app.links.icon
   if (!url) return ''
   let icon
-  const resp = await fetch(`${COZY_URL}${url}`, fetchOptions())
 
-  if (!resp.ok) {
-    throw new Error(`Error while fetching icon: ${resp.statusText}: ${url}`)
+  try {
+    const resp = await fetch(`${COZY_URL}${url}`, fetchOptions())
+    if (!resp.ok)
+      throw new Error(`Error while fetching icon ${resp.statusText}: ${url}`)
+    icon = await resp.blob()
+  } catch (error) {
+    throw error
+  }
+  if (!icon.type) {
+    // iOS10 does not set correctly mime type for images, so we assume
+    // that an empty mime type could mean that the app is running on iOS10.
+    // For regular images like jpeg, png or gif it still works well in the
+    // Safari browser but not for SVG.
+    // So let's set a mime type manually. We cannot always set it to
+    // image/svg+xml and must guess the mime type based on the icon attribute
+    // from app/manifest
+    // See https://stackoverflow.com/questions/38318411/uiwebview-on-ios-10-beta-not-loading-any-svg-images
+    if (!app.icon) {
+      throw new Error(`${app.name}: Cannot detect mime type for icon ${url}`)
+    }
+
+    const extension = app.icon.split('.').pop()
+
+    if (!extension) {
+      throw new Error(
+        `${app.name}: Unable to detect icon mime type from extension (${
+          app.icon
+        })`
+      )
+    }
+
+    if (!mimeTypes[extension]) {
+      throw new Error(`${app.name}: 'Unexpected icon extension (${app.icon})`)
+    }
+
+    icon = new Blob([icon], { type: mimeTypes[extension] })
   }
 
-  icon = await resp.blob()
+  if (icon.type.match(/^image\/.*$/)) {
+    const iconURL = URL.createObjectURL(icon)
+    if (useCache) {
+      cache.icons = cache.icons || {}
+      cache.icons[url] = iconURL
+    }
 
-  // check if MIME type is an image
-  if (!icon.type.match(/^image\/.*$/)) return ''
-  const iconUrl = URL.createObjectURL(icon)
-
-  if (useCache) {
-    cache.icons = cache.icons || {}
-    cache.icons[url] = iconUrl
+    return iconURL
   }
-
-  return iconUrl
+  throw new Error(`${app.name}: icon ${url} is not an image.`)
 }
 
 async function initializeRealtime({
@@ -193,8 +236,6 @@ async function initializeRealtime({
     console.warn(`Cannot initialize realtime in Cozy-bar: ${error.message}`)
   }
 }
-
-const cache = {}
 
 module.exports = {
   async init({ cozyURL, token, onCreateApp, onDeleteApp, ssl }) {

--- a/src/proptypes/index.js
+++ b/src/proptypes/index.js
@@ -1,13 +1,10 @@
 import PropTypes from 'prop-types'
 
 export const appShape = PropTypes.shape({
-  icon: PropTypes.shape({
-    cached: PropTypes.bool,
-    src: PropTypes.string
-  }),
   slug: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   namePrefix: PropTypes.string,
   comingSoon: PropTypes.bool,
-  href: PropTypes.string
+  href: PropTypes.string,
+  links: PropTypes.shape({ icon: PropTypes.string.isRequired })
 })


### PR DESCRIPTION
Ensure that the mime type of an SVG icon is always defined.

This issue seems to be caused by a bug in Cordova, also occurring on iOS10.

See also https://github.com/cozy/cozy-home/pull/989 and https://github.com/cozy/cozy-bar/pull/313