### PR TITLE
Remove url param warning

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -156,9 +156,6 @@ const determineSSL = (ssl, cozyURL) => {
   let parsedURL
   try {
     parsedURL = new URL(cozyURL)
-    console.warn(
-      'Cozy-bar will soon need `ssl` and `domain` parameters to be properly configured, and will not rely on cozyURL.'
-    )
     return parsedURL.protocol === 'https:'
   } catch (error) {
     console.warn(


### PR DESCRIPTION
This warning was here to inform about the future change of how the
cozy-bar is initialized.

After discussing with @kosssi, the cozy-bar initialization will still
be possibile with an url, as the mobile apps are needing it.