### PR TITLE
Require modules instead of mixed aliases

### DIFF
--- a/config/aliases/globalReact.js
+++ b/config/aliases/globalReact.js
@@ -1,1 +1,1 @@
-module.exports = window.React || require('react-bundled')
+module.exports = window.React || require('../../node_modules/react')

--- a/config/aliases/globalReactDOM.js
+++ b/config/aliases/globalReactDOM.js
@@ -1,1 +1,1 @@
-module.exports = window.ReactDOM || require('react-dom-bundled')
+module.exports = window.ReactDOM || require('../../node_modules/react-dom')

--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -18,9 +18,7 @@ module.exports = {
     modules: [SRC_DIR, path.join(__dirname, '../node_modules')],
     alias: {
       react: path.resolve(__dirname, 'aliases/globalReact'),
-      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM'),
-      'react-bundled': 'react',
-      'react-dom-bundled': 'react-dom'
+      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM')
     }
   },
   devtool: '#source-map',


### PR DESCRIPTION
Mixed aliases work as wanted, alias is an alias even in the alias webpack property.