### PR TITLE
feat: Re-fetch apps if app not loaded and drawer opens

### DIFF
--- a/test/components/Bar.spec.jsx
+++ b/test/components/Bar.spec.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Bar } from 'components/Bar'
+import { shallow } from 'enzyme'
+
+describe('Bar', () => {
+
+  let props
+  beforeEach(() => {
+    props = {
+      fetchContext: jest.fn().mockResolvedValue({}),
+      fetchApps: jest.fn().mockResolvedValue([]),
+      fetchSettingsData: jest.fn().mockResolvedValue({}),
+      t: x => x
+    }
+  })
+
+  it('should fetch data when mounted', () => {
+    const root = shallow(
+      <Bar { ...props} />
+    )
+    expect(props.fetchContext).toHaveBeenCalled()
+    expect(props.fetchApps).toHaveBeenCalled()
+    expect(props.fetchSettingsData).toHaveBeenCalled()
+  })
+
+  it('should not fetch data if public', () => {
+    const root = shallow(
+      <Bar { ...props} isPublic={true } />
+    )
+    expect(props.fetchContext).not.toHaveBeenCalled()
+    expect(props.fetchApps).not.toHaveBeenCalled()
+    expect(props.fetchSettingsData).not.toHaveBeenCalled()
+  })
+
+  it('should not fetch apps if hasFetchedApps is true', () => {
+    const root = shallow(
+      <Bar { ...props} hasFetchedApps={true } />
+    )
+    expect(props.fetchApps).toHaveBeenCalled()
+  })
+
+  it('should re-fetch apps if apps are not fetched and drawer opens', () => {
+    const root = shallow(
+      <Bar { ...props} />
+    )
+    expect(props.fetchApps).toHaveBeenCalledTimes(1)
+    root.setState({ drawerVisible: true })
+    expect(props.fetchApps).toHaveBeenCalledTimes(2)
+    root.setState({ drawerVisible: true, usageTracker: {} })
+    expect(props.fetchApps).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Previously, if the user had opened its app while Internet was not
connected, the bar would never load the apps again.

Now, when the drawer opens, we check if we already successfully 
fetched the apps, and if not, we try to fetch again.