### PR TITLE
Fix only 1 store

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:browser:min": "yarn run webpack --env.production",
     "build:mobile:min": "yarn run webpack --env.production --env.target=mobile",
     "watch": "yarn run webpack --watch --display-chunks",
-    "watch:mobile": "yarn run watch:common --env.target=mobile",
+    "watch:mobile": "yarn run watch --env.target=mobile",
     "clean": "rm -rf ./dist/*",
     "lint": "eslint 'config/**/*.{js,jsx}, src/**/*.{js,jsx}'",
     "prebuild": "npm-run-all lint clean tx",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -178,8 +178,8 @@ const init = async ({
     isPublic = true
   }
   // store
-  const createReduxStore = require('lib/store').default
-  const reduxStore = createReduxStore()
+  const getOrCreateStore = require('lib/store').default
+  const reduxStore = getOrCreateStore()
 
   reduxStore.dispatch(setInfos(appName, appNamePrefix, appSlug))
   stack.init({

--- a/src/lib/store/index.js
+++ b/src/lib/store/index.js
@@ -1,6 +1,6 @@
 /* global __DEVELOPMENT__ */
 
-import { createStore, applyMiddleware } from 'redux'
+import { createStore as createReduxStore, applyMiddleware } from 'redux'
 import appsI18nMiddleware from '../middlewares/appsI18n'
 import thunkMiddleware from 'redux-thunk'
 import { persistStore, persistCombineReducers } from 'redux-persist'
@@ -22,11 +22,18 @@ const middlewares = [appsI18nMiddleware, thunkMiddleware]
 
 if (__DEVELOPMENT__) middlewares.push(loggerMiddleware)
 
-const createReduxStore = () => {
-  let store = createStore(reducer, applyMiddleware.apply(null, middlewares))
+export const createStore = () => {
+  store = createReduxStore(reducer, applyMiddleware.apply(null, middlewares))
   persistStore(store)
-
   return store
 }
 
-export default createReduxStore
+let store
+const getOrCreateStore = () => {
+  if (!store) {
+    store = createStore()
+  }
+  return store
+}
+
+export default getOrCreateStore

--- a/test/store/index.spec.js
+++ b/test/store/index.spec.js
@@ -1,4 +1,4 @@
-import createStore from 'lib/store'
+import getOrCreateStore, { createStore } from 'lib/store'
 import { isFetchingApps, getApps, hasFetched } from 'lib/reducers'
 
 describe('store', () => {
@@ -29,5 +29,13 @@ describe('store', () => {
     expect(hasFetched(getState())).toEqual(false)
     store.dispatch({ type: 'RECEIVE_APP_LIST', apps: [] })
     expect(hasFetched(getState())).toEqual(true)
+  })
+})
+
+describe('singleton', () => {
+  it('should work as a singleton', () => {
+    const store = getOrCreateStore()
+    const store2 = getOrCreateStore()
+    expect(store).toEqual(store2)
   })
 })


### PR DESCRIPTION
The delaying of the instantiation of the store changed the module level variable to a function level variable. This meant that there could be several store instances and led to a bug where the Bar was not properly refreshed after a dispatch (the exported Bar component would dispatch on a store, where the connected store was another one).