### PR TITLE
fix: Revert "chore(deps): update dependency babel-loader to v8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "autoprefixer": "9.4.2",
     "babel-jest": "23.6.0",
-    "babel-loader": "8.0.4",
+    "babel-loader": "7.1.5",
     "babel-polyfill": "6.26.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,15 +1908,14 @@ babel-jest@23.6.0, babel-jest@^23.6.0:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
 
-babel-loader@8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.4.tgz#7bbf20cbe4560629e2e41534147692d3fecbdce6"
-  integrity sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==
+babel-loader@7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
+  integrity sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
-    util.promisify "^1.0.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"


### PR DESCRIPTION
This upgrade made some errors during develoment build
```
WARNING in ./src/lib/intents.js 6:9-22
"export 'cozyFetchJSON' was not found in './stack'
 @ ./src/components/SearchBar.jsx
 @ ./src/components/Bar.jsx
 @ ./src/index.jsx

WARNING in ./src/lib/intents.js 137:22-35
"export 'cozyFetchJSON' was not found in './stack'
 @ ./src/components/SearchBar.jsx
 @ ./src/components/Bar.jsx
 @ ./src/index.jsx

WARNING in ./src/lib/reducers/apps.js 101:23-28
"export 'default' (imported as 'stack') was not found in '../stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx

WARNING in ./src/lib/reducers/apps.js 162:50-55
"export 'default' (imported as 'stack') was not found in '../stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx

WARNING in ./src/index.jsx 207:12-17
"export 'default' (imported as 'stack') was not found in './lib/stack'

WARNING in ./src/index.jsx 248:2-7
"export 'default' (imported as 'stack') was not found in './lib/stack'

WARNING in ./src/lib/reducers/settings.js 199:23-28
"export 'default' (imported as 'stack') was not found in 'lib/stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx

WARNING in ./src/lib/reducers/context.js 58:23-28
"export 'default' (imported as 'stack') was not found in 'lib/stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx

WARNING in ./src/lib/reducers/settings.js 48:23-28
"export 'default' (imported as 'stack') was not found in 'lib/stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx

WARNING in ./src/components/Apps/AppItem.jsx 172:17-22
"export 'default' (imported as 'stack') was not found in 'lib/stack'
 @ ./src/components/Apps/AppsContent.jsx
 @ ./src/components/Drawer.jsx
 @ ./src/components/Bar.jsx
 @ ./src/index.jsx

WARNING in ./src/lib/reducers/settings.js 103:23-28
"export 'default' (imported as 'stack') was not found in 'lib/stack'
 @ ./src/lib/reducers/index.js
 @ ./src/index.jsx
```
Need to investigate more about that