### PR TITLE
feat: Bar should use transpiled version of ui

### DIFF
--- a/src/components/Apps/AppNavButtons.jsx
+++ b/src/components/Apps/AppNavButtons.jsx
@@ -4,7 +4,8 @@ import { connect } from 'react-redux'
 import { getHomeApp } from 'lib/reducers'
 
 import { translate } from 'cozy-ui/react/I18n'
-import Icon from 'cozy-ui/react/Icon'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+
 import HomeIcon from './IconCozyHome'
 import { isFetchingApps } from 'lib/reducers'
 


### PR DESCRIPTION
Since UI is now shipped in a transpiled way we have two choices : 
- use the transpiled version of UI in the bar 
- use the non transpiled version of UI in the bar, but the bar should transpile it 

I just changed the icons since this is the only place I have an error and I want this fix to be merged ASAP, but we should consider to move to the first solution ? 