### PR TITLE
fix: Disable searchBar on mobileApp

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "cozy-bar.js library, a small lib provided by cozy-stack to inject the Cozy-bar component into each app",
   "main": "dist/cozy-bar.js",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozy.io/)",
-  "contributors": ["m4dz (https://m4dz.net)", "CPatchane"],
+  "contributors": [
+    "m4dz (https://m4dz.net)",
+    "CPatchane"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/cozy/cozy-bar.git"
@@ -94,6 +97,7 @@
     "cozy-client-js": "0.14.2",
     "cozy-device-helper": "1.5.0",
     "cozy-realtime": "1.2.5",
+    "enzyme-to-json": "^3.3.5",
     "hammerjs": "2.0.8",
     "lerna-changelog": "0.8.2",
     "localforage": "1.7.3",
@@ -114,9 +118,20 @@
     }
   ],
   "jest": {
-    "moduleFileExtensions": ["js", "jsx", "json", "styl", "yaml"],
-    "setupFiles": ["<rootDir>/test/jestLib/setup.js"],
-    "moduleDirectories": ["node_modules", "src"],
+    "moduleFileExtensions": [
+      "js",
+      "jsx",
+      "json",
+      "styl",
+      "yaml"
+    ],
+    "setupFiles": [
+      "<rootDir>/test/jestLib/setup.js"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "transform": {
       "\\.yaml$": "yaml-jest",
       "\\.(js|jsx)$": "babel-jest"
@@ -128,7 +143,9 @@
       "\\.(png|gif|jpe?g|svg)$": "<rootDir>/test/__mocks__/fileMock.js",
       "styles": "identity-obj-proxy"
     },
-    "transformIgnorePatterns": ["node_modules/(?!cozy-ui)"],
+    "transformIgnorePatterns": [
+      "node_modules/(?!cozy-ui)"
+    ],
     "globals": {
       "__ALLOW_HTTP__": false,
       "__TARGET__": "browser",

--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -10,6 +10,7 @@ import {
   getTracker,
   configureTracker
 } from 'cozy-ui/react/helpers/tracker'
+import { isMobileApp } from 'cozy-device-helper'
 
 import Banner from 'components/Banner'
 import Drawer from 'components/Drawer'
@@ -37,7 +38,8 @@ class Bar extends Component {
       drawerVisible: false,
       usageTracker: null,
       supportDisplayed: false,
-      searchBarEnabled: props.currentApp === 'Cozy Drive' && !props.isPublic
+      searchBarEnabled:
+        props.currentApp === 'Cozy Drive' && !props.isPublic && !isMobileApp()
     }
   }
 

--- a/test/components/Bar.spec.jsx
+++ b/test/components/Bar.spec.jsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import { Bar } from 'components/Bar'
 import { shallow } from 'enzyme'
+import { isMobileApp } from 'cozy-device-helper'
+import toJson from 'enzyme-to-json'
+jest.mock('cozy-device-helper', () => ({
+  ...require.requireActual('cozy-device-helper'),
+  isMobileApp: jest.fn()
+}))
 
 describe('Bar', () => {
-
   let props
   beforeEach(() => {
+    isMobileApp.mockReturnValue(false)
     props = {
       fetchContext: jest.fn().mockResolvedValue({}),
       fetchApps: jest.fn().mockResolvedValue([]),
@@ -15,38 +21,61 @@ describe('Bar', () => {
   })
 
   it('should fetch data when mounted', () => {
-    const root = shallow(
-      <Bar { ...props} />
-    )
+    const root = shallow(<Bar {...props} />)
     expect(props.fetchContext).toHaveBeenCalled()
     expect(props.fetchApps).toHaveBeenCalled()
     expect(props.fetchSettingsData).toHaveBeenCalled()
   })
 
   it('should not fetch data if public', () => {
-    const root = shallow(
-      <Bar { ...props} isPublic={true } />
-    )
+    const root = shallow(<Bar {...props} isPublic={true} />)
     expect(props.fetchContext).not.toHaveBeenCalled()
     expect(props.fetchApps).not.toHaveBeenCalled()
     expect(props.fetchSettingsData).not.toHaveBeenCalled()
   })
 
   it('should not fetch apps if hasFetchedApps is true', () => {
-    const root = shallow(
-      <Bar { ...props} hasFetchedApps={true } />
-    )
+    const root = shallow(<Bar {...props} hasFetchedApps={true} />)
     expect(props.fetchApps).toHaveBeenCalled()
   })
 
   it('should re-fetch apps if apps are not fetched and drawer opens', () => {
-    const root = shallow(
-      <Bar { ...props} />
-    )
+    const root = shallow(<Bar {...props} />)
     expect(props.fetchApps).toHaveBeenCalledTimes(1)
     root.setState({ drawerVisible: true })
     expect(props.fetchApps).toHaveBeenCalledTimes(2)
     root.setState({ drawerVisible: true, usageTracker: {} })
     expect(props.fetchApps).toHaveBeenCalledTimes(2)
+  })
+
+  it('should display the Searchbar', () => {
+    const root = shallow(
+      <Bar {...props} currentApp="Cozy Drive" isPublic={false} />
+    )
+    expect(toJson(root)).toMatchSnapshot()
+  })
+
+  it('should not display searchbar if we are on mobile', () => {
+    isMobileApp.mockReturnValue(true)
+    const root = shallow(
+      <Bar {...props} currentApp="Cozy Drive" isPublic={false} />
+    )
+    expect(toJson(root)).toMatchSnapshot()
+  })
+
+  it('should not display searchbar if we are not on Cozy Drive', () => {
+    isMobileApp.mockReturnValue(true)
+    const root = shallow(
+      <Bar {...props} currentApp="Cozy Contacts" isPublic={false} />
+    )
+    expect(toJson(root)).toMatchSnapshot()
+  })
+
+  it('should not display searchbar if we are not on  a public page', () => {
+    isMobileApp.mockReturnValue(true)
+    const root = shallow(
+      <Bar {...props} currentApp="Cozy Drive" isPublic={true} />
+    )
+    expect(toJson(root)).toMatchSnapshot()
   })
 })

--- a/test/components/__snapshots__/Bar.spec.jsx.snap
+++ b/test/components/__snapshots__/Bar.spec.jsx.snap
@@ -1,0 +1,143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bar should display the Searchbar 1`] = `
+<div
+  className="coz-bar-wrapper"
+>
+  <div
+    className="coz-bar-container"
+  >
+    <button
+      className="coz-bar-btn coz-bar-burger"
+      data-icon="icon-apps"
+      data-tutorial="apps-mobile"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="coz-bar-hidden"
+      >
+        drawer
+      </span>
+    </button>
+    <Apps
+      isPublic={false}
+    />
+    <div
+      className="u-flex-grow"
+    >
+      <Wrapper />
+    </div>
+    <Wrapper
+      toggleSupport={[Function]}
+    />
+    <Connect(Drawer)
+      drawerListener={[Function]}
+      isClaudyLoading={false}
+      onClaudy={false}
+      onClose={[Function]}
+      toggleSupport={[Function]}
+      visible={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`Bar should not display searchbar if we are not on  a public page 1`] = `
+<div
+  className="coz-bar-wrapper"
+>
+  <div
+    className="coz-bar-container"
+  >
+    <Apps
+      isPublic={true}
+    />
+    <div
+      className="u-flex-grow"
+    />
+  </div>
+</div>
+`;
+
+exports[`Bar should not display searchbar if we are not on Cozy Drive 1`] = `
+<div
+  className="coz-bar-wrapper"
+>
+  <div
+    className="coz-bar-container"
+  >
+    <button
+      className="coz-bar-btn coz-bar-burger"
+      data-icon="icon-apps"
+      data-tutorial="apps-mobile"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="coz-bar-hidden"
+      >
+        drawer
+      </span>
+    </button>
+    <Apps
+      isPublic={false}
+    />
+    <div
+      className="u-flex-grow"
+    />
+    <Wrapper
+      toggleSupport={[Function]}
+    />
+    <Connect(Drawer)
+      drawerListener={[Function]}
+      isClaudyLoading={false}
+      onClaudy={false}
+      onClose={[Function]}
+      toggleSupport={[Function]}
+      visible={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`Bar should not display searchbar if we are on mobile 1`] = `
+<div
+  className="coz-bar-wrapper"
+>
+  <div
+    className="coz-bar-container"
+  >
+    <button
+      className="coz-bar-btn coz-bar-burger"
+      data-icon="icon-apps"
+      data-tutorial="apps-mobile"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="coz-bar-hidden"
+      >
+        drawer
+      </span>
+    </button>
+    <Apps
+      isPublic={false}
+    />
+    <div
+      className="u-flex-grow"
+    />
+    <Wrapper
+      toggleSupport={[Function]}
+    />
+    <Connect(Drawer)
+      drawerListener={[Function]}
+      isClaudyLoading={false}
+      onClaudy={false}
+      onClose={[Function]}
+      toggleSupport={[Function]}
+      visible={false}
+    />
+  </div>
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3840,7 +3840,7 @@ cozy-client-js@0.14.2:
     core-js "^2.5.3"
     isomorphic-fetch "^2.2.1"
     pouchdb "6.4.3"
-    pouchdb-adapter-cordova-sqlite "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
+    pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "6.4.3"
 
 cozy-device-helper@1.5.0:
@@ -4626,6 +4626,13 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.1.0"
     prop-types "^15.6.2"
     semver "^5.6.0"
+
+enzyme-to-json@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
 
 enzyme@3.2.0:
   version "3.2.0"
@@ -9770,7 +9777,6 @@ pouchdb-abstract-mapreduce@6.4.3:
 
 "pouchdb-adapter-cordova-sqlite@git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
   resolved "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
   dependencies:
     pouchdb-adapter-websql-core "^6.1.1"


### PR DESCRIPTION
Currently, the SearchBar is activated only on Drive and when not on a public page. 

This bar is hidden with a media-query, but this media-query is not enough for some iPad. So we decided to disable the search bar when we are in a cordova app