### PR TITLE
Use relative node_modules in webpack config

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.json', '.yaml'],
-    modules: [SRC_DIR, path.join(__dirname, '../node_modules')],
+    modules: [SRC_DIR, 'node_modules'],
     alias: {
       react: path.resolve(__dirname, 'aliases/globalReact'),
       'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM')


### PR DESCRIPTION
Webpack process differently absolute path vs relative path for `node_modules`, it's better to avoid absolute path.