### PR TITLE
Remove persisted locale + close drawer on app switch

### DIFF
--- a/src/components/Apps/AppsContent.jsx
+++ b/src/components/Apps/AppsContent.jsx
@@ -18,7 +18,14 @@ class AppsContent extends Component {
   }
 
   render() {
-    const { t, apps, breakpoints, homeApp, isFetchingApps } = this.props
+    const {
+      t,
+      apps,
+      breakpoints,
+      homeApp,
+      isFetchingApps,
+      onAppSwitch
+    } = this.props
     const { isMobile } = breakpoints
     const isHomeApp = homeApp && homeApp.isCurrentApp
 
@@ -29,14 +36,19 @@ class AppsContent extends Component {
     return (
       <div className="coz-nav-pop-content">
         <ul className="coz-nav-group">
-          {isMobile && homeApp && <AppItem app={homeApp} useHomeIcon />}
+          {isMobile &&
+            homeApp && (
+              <AppItem app={homeApp} useHomeIcon onAppSwitch={onAppSwitch} />
+            )}
           {isFetchingApps
             ? new Array(3)
                 .fill({})
                 .map((nothing, index) => <AppItemPlaceholder key={index} />)
             : apps
                 .sort(sorter(this.translateApp))
-                .map((app, index) => <AppItem app={app} key={index} />)}
+                .map((app, index) => (
+                  <AppItem app={app} key={index} onAppSwitch={onAppSwitch} />
+                ))}
         </ul>
         {homeApp &&
           !isMobile &&

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -136,7 +136,7 @@ class Drawer extends Component {
     })
   }
 
-  close() {
+  close = () => {
     if (this.state.isClosing) return
     this.detachGestures()
     this.setState(() => ({ isClosing: true }))
@@ -177,7 +177,7 @@ class Drawer extends Component {
           }}
         >
           <nav className="coz-drawer--apps">
-            <AppsContent />
+            <AppsContent onAppSwitch={this.close} />
           </nav>
           <hr className="coz-sep-flex" />
           <nav className="coz-drawer--settings">

--- a/src/lib/store/index.js
+++ b/src/lib/store/index.js
@@ -11,7 +11,7 @@ import storage from 'redux-persist/lib/storage'
 const config = {
   storage,
   key: 'cozy-bar',
-  whitelist: ['locale', 'apps', 'context']
+  whitelist: ['apps', 'context']
 }
 
 // copied and changed from https://github.com/LogRocket/redux-logger/blob/3ca9f2c1ecf17a7acf18c6fa0bbf4b6b239738f1/src/core.js#L25

--- a/test/components/AppItem.spec.jsx
+++ b/test/components/AppItem.spec.jsx
@@ -48,8 +48,37 @@ describe('app icon', () => {
     const root = shallow(<AppItem t={tMock} app={app} />)
     root.find('a').simulate('click')
     expect(openNativeSpy).not.toHaveBeenCalled()
-    root.setState({ isAppAvailable: true })
+    root.setState({ isMobileAppAvailable: true })
     root.find('a').simulate('click')
     expect(openNativeSpy).toHaveBeenCalled()
+  })
+
+  it('should change the onClick handler to use onAppSwitch if current app is mobile', () => {
+    const app = {
+      slug: 'cozy-drive',
+      name: 'Drive'
+    }
+    const appSwitchMock = jest.fn()
+    const root = shallow(
+      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
+    )
+    root.find('a').simulate('click')
+    expect(appSwitchMock).not.toHaveBeenCalled()
+    root.setState({ isMobileAppAvailable: true })
+    root.find('a').simulate('click')
+    expect(appSwitchMock).toHaveBeenCalled()
+  })
+
+  it('should not change the onClick handler if current app is web and target app is web too', () => {
+    const app = {
+      slug: 'cozy-store',
+      name: 'Store'
+    }
+    const appSwitchMock = jest.fn()
+    const root = shallow(
+      <AppItem t={tMock} app={app} onAppSwitch={appSwitchMock} />
+    )
+    root.find('a').simulate('click')
+    expect(appSwitchMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
* Persisted locale was causing issue on locale changing and it was not used
* Now the drawer is closed on app item click if:
  * target app is **web** and current app is **mobile**
  * target app is **mobile** and current app is **mobile**
  * target app is **mobile** and current app is **web**