### PR TITLE
chore: Remove the onboarding from the hidden apps

### DIFF
--- a/src/lib/reducers/apps.js
+++ b/src/lib/reducers/apps.js
@@ -9,7 +9,7 @@ const RECEIVE_HOME_APP = 'RECEIVE_HOME_APP'
 const FETCH_APPS = 'FETCH_APPS'
 const FETCH_APPS_FAILURE = 'FETCH_APPS_FAILURE'
 const SET_INFOS = 'SET_INFOS'
-const EXCLUDES = ['settings', 'onboarding']
+const EXCLUDES = ['settings']
 
 const isCurrentApp = (state, app) => app.slug === state.appSlug
 


### PR DESCRIPTION
The whole onboarding is now part of the stack.

See also https://github.com/cozy/cozy-store/pull/547 and https://github.com/cozy/cozy-home/pull/1113