### PR TITLE
fix: Stop polyfiling Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@babel/core": "7.2.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-preset-cozy-app": "1.3.2",
-    "core-js": "2.6.4",
     "cozy-client-js": "0.14.2",
     "cozy-device-helper": "1.6.5",
     "cozy-realtime": "2.0.3",

--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -1,6 +1,5 @@
 /* global __PIWIK_TRACKER_URL__  __PIWIK_SITEID__ __PIWIK_DIMENSION_ID_APP__ */
 
-import 'core-js/modules/es6.object.assign'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,11 +3771,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
-  integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"


### PR DESCRIPTION
We import a polyfill for `Object.assign` from `core-js`. Since version 2.6.4, this somehow also polyfills `fetch`, which in turn causes other problems.

The initial reason for using the polyfill is discussed [here](https://github.com/cozy/cozy-bar/issues/172) but it boils down to supporting `Object.assign` calls in cozy-ui on IE11. In the meantime, we transpile cozy-ui so `Object.assign` calls are transformed when needed, but also we dropped IE11 support. So I suggest we remove this dependency altogether from the bar.