### PR TITLE
feat: No need to override anymore if it's the same app

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -117,12 +117,6 @@ export class AppItem extends React.Component {
       }
     }
 
-    if (app.isCurrentApp) {
-      // disabled for current app
-      onClick = null
-      href = null
-    }
-
     return (
       <li
         className={`coz-nav-apps-item${app.isCurrentApp ? ' --current' : ''}`}


### PR DESCRIPTION
We don't need to override the current application since it breaks some use case (coming from deeplink for instance) 