### PR TITLE
Get back settings app handling

### DIFF
--- a/src/lib/stack-client.js
+++ b/src/lib/stack-client.js
@@ -10,6 +10,7 @@ import {
   ServerErrorException,
   NotFoundException,
   MethodNotAllowedException,
+  UnavailableSettingsException,
   UnavailableStackException,
   UnauthorizedStackException
 } from 'lib/exceptions'
@@ -332,6 +333,15 @@ const cozyFetchJSON = function(cozy, method, path, body) {
   })
 }
 
+const getSettingsAppURL = function() {
+  return getApp('settings').then(settings => {
+    if (!settings) {
+      throw new UnavailableSettingsException()
+    }
+    return settings.links.related
+  })
+}
+
 /**
  * Initializes the functions to call the cozy stack
  *
@@ -361,7 +371,8 @@ export default {
     storageData: getStorageData,
     iconProps: getAppIconProps,
     cozyURL: getCozyURLOrigin,
-    intents: getIntents
+    intents: getIntents,
+    settingsAppURL: getSettingsAppURL
   },
   updateAccessToken,
   cozyFetchJSON,

--- a/src/lib/stack.js
+++ b/src/lib/stack.js
@@ -50,7 +50,8 @@ const get = {
   context: (...args) => current().get.context(...args),
   storageData: (...args) => current().get.storageData(...args),
   iconProps: (...args) => current().get.iconProps(...args),
-  cozyURL: (...args) => current().get.cozyURL(...args)
+  cozyURL: (...args) => current().get.cozyURL(...args),
+  settingsAppURL: (...args) => current().get.settingsAppURL(...args)
 }
 
 const stackProxy = {


### PR DESCRIPTION
Was removed by accident when refactoring the stack to handle cozy-client