### PR TITLE
fix: Set color on nav apps main button

### DIFF
--- a/src/styles/apps.css
+++ b/src/styles/apps.css
@@ -17,6 +17,7 @@
   padding: 0;
   background-color: transparent;
   border: none;
+  color: black;
 }
 
 [role=banner] .coz-nav-apps-btns-main:hover,


### PR DESCRIPTION
This avoids white text on white background on systems with dark theme

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/1606068/55496152-aa803200-563e-11e9-9c34-a800db1b485b.png)|![image](https://user-images.githubusercontent.com/1606068/55496109-9e947000-563e-11e9-841c-3728f4084e7a.png)|
