### PR TITLE
fix: Upgrade cozy-device-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-preset-cozy-app": "1.5.1",
     "cozy-client": "6.20.0",
-    "cozy-device-helper": "1.7.0",
+    "cozy-device-helper": "1.7.1",
     "cozy-harvest-lib": "0.39.3",
     "cozy-interapp": "0.4.4",
     "cozy-realtime": "2.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,10 +3835,10 @@ cozy-device-helper@1.6.3:
   dependencies:
     lodash "4.17.11"
 
-cozy-device-helper@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.7.0.tgz#900fc4e77ad6f0ff6a87ed1a683039ed3dbb2bad"
-  integrity sha512-YL5viPiGGwA9jchZbb7narwQybZMrBWnBZrvFcRbp8F4WOqU+8z6hBXNlhAN9Ns6NzX5+O13c18VVLzOqKfXtQ==
+cozy-device-helper@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.7.1.tgz#56c57a14b423de2700a0a695c3f7710cf6a2383d"
+  integrity sha512-CTEJOzRK+AtrGN/Wqjj5n0DM1mMMvNGSZDxKlTCvY0FNYYko05vX5qIEb9vFVm7UhH7GFZjZ+S73g3Kwq/hF4Q==
   dependencies:
     lodash "4.17.11"
 


### PR DESCRIPTION
Upgrade cozy-device-helper to fix deeplinking issue on iOS 12 2 + 