### PR TITLE
Allow overriding AppItem href

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -9,6 +9,17 @@ import stack from 'lib/stack'
 import PropTypes from 'prop-types'
 
 export class AppItem extends React.Component {
+  /**
+   * Used to add query params to AppLinker links, useful in overrides
+   * @param  {Object} props   AppItem props
+   * @param  {Object} context AppItem context
+   * @return {Object}         Query string parameters as object
+   */
+  static buildQueryParams = () => {
+    // default behaviour
+    return null
+  }
+
   constructor(props) {
     super(props)
     this.onAppSwitch = this.onAppSwitch.bind(this)
@@ -16,6 +27,17 @@ export class AppItem extends React.Component {
 
   componentWillUnmount() {
     if (this.switchTimeout) clearTimeout(this.switchTimeout)
+  }
+
+  buildAppUrl(href) {
+    const url = new URL(href)
+    const queryParams = AppItem.buildQueryParams(this.props, this.context)
+    if (queryParams) {
+      for (const name in queryParams) {
+        url.searchParams.append(name, queryParams[name])
+      }
+    }
+    return url.toString()
   }
 
   onAppSwitch() {
@@ -46,7 +68,7 @@ export class AppItem extends React.Component {
             >
               <a
                 role="menuitem"
-                href={href}
+                href={this.buildAppUrl(href)}
                 data-icon={dataIcon}
                 title={label}
                 onClick={onClick}

--- a/test/components/AppItem.spec.jsx
+++ b/test/components/AppItem.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { AppItem } from 'components/Apps/AppItem'
-import { mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import { tMock } from '../jestLib/I18n'
 import { isMobileApp, isMobile } from 'cozy-device-helper'
@@ -26,6 +26,38 @@ jest.mock('cozy-device-helper', () => ({
   isMobile: jest.fn(),
   openDeeplinkOrRedirect: jest.fn()
 }))
+
+const app = {
+  slug: 'cozy-drive',
+  name: 'Drive',
+  href: 'http://fake.fr'
+}
+
+describe('AppItem', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('buildAppUrl', () => {
+    it('should return untouched href', () => {
+      const wrapper = shallow(<AppItem app={app} t={tMock} />)
+      const url = wrapper.instance().buildAppUrl('http://fake.fr')
+      expect(url).toBe('http://fake.fr/')
+    })
+
+    it('should update query string', () => {
+      jest.spyOn(AppItem, 'buildQueryParams').mockReturnValue({
+        foo: 'bar',
+        bar: 'buz'
+      })
+
+      const wrapper = shallow(<AppItem app={app} t={tMock} />)
+      const url = wrapper.instance().buildAppUrl('http://fake.fr')
+      expect(url).toBe('http://fake.fr/?foo=bar&bar=buz')
+    })
+  })
+})
+
 describe('app icon', () => {
   let spyConsoleError
 
@@ -54,11 +86,6 @@ describe('app icon', () => {
 
   it('should render correctly with target mobile and providing fetchIcon to AppIcon', () => {
     global.__TARGET__ = 'mobile'
-    const app = {
-      slug: 'cozy-drive',
-      name: 'Drive',
-      href: 'http://fake.fr'
-    }
     const root = mount(<AppItem t={tMock} app={app} />)
     expect(toJson(root)).toMatchSnapshot()
   })

--- a/test/components/__snapshots__/AppItem.spec.jsx.snap
+++ b/test/components/__snapshots__/AppItem.spec.jsx.snap
@@ -22,7 +22,7 @@ exports[`app icon should render correctly 1`] = `
     >
       <a
         data-icon="icon-cozy-drive"
-        href="http://fake.fr"
+        href="http://fake.fr/"
         onClick={null}
         role="menuitem"
         title="Drive"
@@ -77,7 +77,7 @@ exports[`app icon should render correctly with target mobile and providing fetch
     >
       <a
         data-icon="icon-cozy-drive"
-        href="http://fake.fr"
+        href="http://fake.fr/"
         onClick={null}
         role="menuitem"
         title="Drive"


### PR DESCRIPTION
This PR is a quick try to answer to our need of passing argument in an AppLinker href in Cozy-Bar.

~~The idea is to be able to override current href using Component inheritance:~~

~~Another alternative should be to implement directly query parameter as an `AppLinker` prop and let it generate the href. What do you think ?~~

How this should work:

```jsx
import 'AppItem' from 'original-bar/src/components/AppItem'

AppItem.buildQueryParams = (props, context) => ({
  foo: 'bar'
})

export AppItem
```
