### PR TITLE
fix: Removed React warning during tests

### DIFF
--- a/test/components/AppItem.spec.jsx
+++ b/test/components/AppItem.spec.jsx
@@ -10,7 +10,7 @@ jest.mock('lib/stack', () => ({
   get: {
     iconProps: () => {
       return global.__TARGET__ === 'mobile'
-        ? { fetchIcon: jest.fn }
+        ? { fetchIcon: jest.fn().mockResolvedValue('http://urlOfIcon') }
         : {
             // we mustn't give the protocol here
             domain: 'cozy.tools',

--- a/test/components/__snapshots__/AppItem.spec.jsx.snap
+++ b/test/components/__snapshots__/AppItem.spec.jsx.snap
@@ -91,7 +91,27 @@ exports[`app icon should render correctly with target mobile and providing fetch
             }
           }
           className="coz-nav-apps-item-icon"
-          fetchIcon={[Function]}
+          fetchIcon={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "href": "http://fake.fr",
+                    "name": "Drive",
+                    "slug": "cozy-drive",
+                  },
+                  undefined,
+                  undefined,
+                ],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": Promise {},
+                },
+              ],
+            }
+          }
           key="cozy-drive"
         >
           <div


### PR DESCRIPTION
React was complaining that the src attribute of the img tag
rendered by AppItem was invalid.