### PR TITLE
fix: No warning for url/token when using new cozy-client

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -182,13 +182,21 @@ const init = async ({
   lang,
   iconPath = getDefaultIcon(),
   cozyClient,
-  cozyURL = getDefaultStackURL(),
-  token = getDefaultToken(),
+  cozyURL,
+  token,
   replaceTitleOnMobile = false,
   isPublic = false,
   onLogOut,
   ssl
 } = {}) => {
+  if (cozyURL === undefined && !cozyClient) {
+    cozyURL = getDefaultStackURL()
+  }
+
+  if (token === undefined && !cozyClient) {
+    token = getDefaultToken()
+  }
+
   // Force public mode in `/public` URLs
   if (/^\/public/.test(window.location.pathname)) {
     isPublic = true


### PR DESCRIPTION
Since the URL/token are taken from cozy-client when the bar is initialized with cozyClient, there is no need to issue a warning if they are not present and cozyClient is.