### PR TITLE
Always import CozyClient when needed by bar

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,6 @@
 
 'use strict'
 
-import CozyClient from 'cozy-client'
 import stack from 'lib/stack'
 import {
   getLocale,
@@ -205,6 +204,7 @@ const init = async ({
       token: ccToken
     }
     console.warn('Automatically made cozyClient. Options: ', ccOptions)
+    const CozyClient = require('cozy-client').default
     cozyClient = new CozyClient({})
     // TODO, initializing CozyClient with a uri/token should automatically
     // call login(). Without login(), CozyClient.isLogged is false.


### PR DESCRIPTION
CozyClient seems to import somewhere React or a React based library so it this won't work with Preact in Cozy-Home, require CozyClient on init fix that issue.
This issue was causing a blank bar in cozy-home.