### PR TITLE
Append query string in AppLinker href prop 🚑

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -55,7 +55,11 @@ export class AppItem extends React.Component {
     const dataIcon = app.slug ? `icon-${app.slug}` : ''
 
     return (
-      <AppLinker onAppSwitch={this.onAppSwitch} slug={app.slug} href={app.href}>
+      <AppLinker
+        onAppSwitch={this.onAppSwitch}
+        slug={app.slug}
+        href={this.buildAppUrl(app.href)}
+      >
         {({ onClick, href }) => {
           const label = t(`${app.slug}.name`, {
             _: app.namePrefix ? `${app.namePrefix} ${app.name}` : app.name
@@ -68,7 +72,7 @@ export class AppItem extends React.Component {
             >
               <a
                 role="menuitem"
-                href={this.buildAppUrl(href)}
+                href={href}
                 data-icon={dataIcon}
                 title={label}
                 onClick={onClick}

--- a/test/components/__snapshots__/AppItem.spec.jsx.snap
+++ b/test/components/__snapshots__/AppItem.spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`app icon should render correctly 1`] = `
   t={[Function]}
 >
   <AppLinker
-    href="http://fake.fr"
+    href="http://fake.fr/"
     nativePath="/"
     onAppSwitch={[Function]}
     slug="cozy-drive"
@@ -67,7 +67,7 @@ exports[`app icon should render correctly with target mobile and providing fetch
   t={[Function]}
 >
   <AppLinker
-    href="http://fake.fr"
+    href="http://fake.fr/"
     nativePath="/"
     onAppSwitch={[Function]}
     slug="cozy-drive"


### PR DESCRIPTION
App URLs with query string  were not properly encoded.

Let AppLinker manage the href with query string.