### PR TITLE
fix: Add protocol to default stack url

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -106,7 +106,9 @@ const getDefaultStackURL = isPublic => {
     }
     return ''
   }
-  return data.cozyDomain
+
+  const protocol = window.location.protocol
+  return `${protocol}//${data.cozyDomain}`
 }
 
 const getDefaultToken = isPublic => {


### PR DESCRIPTION
When the cozy-bar instantiates its own cozy-client, it needs a valid `uri`. The protocol was missing. 

Note that if the app initializes the bar with a `cozyURL`, it has to provide an URL with protocol : https://github.com/cozy/cozy-bar/blob/master/src/index.jsx#L200 