### PR TITLE
fix: Key should be uniq

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -320,8 +320,8 @@ class SearchBar extends Component {
 
     return (
       <div className="coz-searchbar" role="search">
-        {sourceURLs.map(url => (
-          <iframe src={url} style={{ display: 'none' }} key={url} />
+        {sourceURLs.map((url, i) => (
+          <iframe src={url} style={{ display: 'none' }} key={url + i} />
         ))}
         <Autosuggest
           theme={theme}


### PR DESCRIPTION
URL should be enough is a vaste majority of use case. But in my case, I've several `Drive` installed and I got a few warnings complaining about the key not being unique. 