### PR TITLE
chore: Remove log for React dev tools message

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -160,7 +160,10 @@ class SearchBar extends Component {
       })
       delete source.resolvers[event.data.id]
     } else {
-      console.log('unhandled message:', event)
+      //We remove react devTools message.
+      if (!/^react-devtools/gi.test(event.data.source)) {
+        console.log('unhandled message:', event)
+      }
     }
   }
 


### PR DESCRIPTION
React-dev-tools sends message but the bar log every message. 

See https://github.com/facebook/react-devtools/issues/812 