### PR TITLE
fix: cozy-client should be a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-runtime": "6.26.0",
     "bundlesize": "0.17.1",
     "cozy-authentication": "^1.13.0",
+    "cozy-client": "6.31.1",
     "css-loader": "1.0.1",
     "css-mqpacker": "7.0.0",
     "cssnano-preset-advanced": "^4.0.7",
@@ -93,7 +94,6 @@
     "@babel/core": "7.3.4",
     "babel-core": "7.0.0-bridge.0",
     "babel-preset-cozy-app": "1.5.1",
-    "cozy-client": "6.31.1",
     "cozy-device-helper": "1.7.1",
     "cozy-interapp": "0.4.4",
     "cozy-realtime": "3.0.0",
@@ -113,6 +113,9 @@
     "redux": "3.7.2",
     "redux-persist": "5.10.0",
     "redux-thunk": "2.3.0"
+  },
+  "peerDependencies": {
+    "cozy-client": "*"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
We have issues with the cozy-stack-client version on drive. It seems to come from here