### PR TITLE
fix: Add missing CSS utils

### DIFF
--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -19,6 +19,8 @@
 @import 'settings/z-index'
 @import 'tools/mixins'
 @import 'utilities/display'
+@import 'utilities/position'
+@import 'utilities/dimensions'
 
 @import 'components/button.styl'
 


### PR DESCRIPTION
Some utility classes were called but they weren't in the transpiled cozy-ui so I explicitely added them to cozy-bar styles.