### PR TITLE
WIP feat: Light bar

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -18,6 +18,7 @@ module.exports = (env = {}) => {
   return merge(
     require('./webpack.config.base.js'),
     addAnalyzer ? require('./webpack.config.analyzer.js') : {},
+    env.light ? require('./webpack.target.light.js') : {},
     require('./webpack.config.jsx.js'),
     require(production ? './webpack.config.prod' : './webpack.config.dev'),
     cssConfig({ filename, mobile, production }),

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const webpack = require('webpack')
 const merge = require('webpack-merge')
 const vars = require('./webpack.vars')
 
@@ -26,12 +25,7 @@ module.exports = (env = {}) => {
       output: {
         filename: filename('js', mobile ? 'mobile' : ''),
         path: path.resolve(__dirname, '../dist')
-      },
-      plugins: [
-        new webpack.DefinePlugin({
-          __TARGET__: JSON.stringify(mobile ? 'mobile' : 'browser')
-        })
-      ]
+      }
     }
   )
 }

--- a/config/webpack.target.light.js
+++ b/config/webpack.target.light.js
@@ -1,0 +1,10 @@
+module.exports = {
+  externals: {
+    'cozy-client': 'CozyClient',
+    'cozy-stack-client': 'CozyStackClient',
+    'cozy-ui': 'CozyUI',
+    lodash: '_',
+    'my-react-dom': 'ReactDOM',
+    'my-react': 'React'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,9 @@
     "prepublishOnly": "yarn build",
     "build": "npm-run-all --parallel 'build:*' 'build:*:*'",
     "webpack": "webpack --config ./config/webpack.js",
-    "build:browser": "yarn run webpack",
-    "build:mobile": "yarn run webpack --env.target=mobile",
-    "build:browser:min": "yarn run webpack --env.production",
-    "build:mobile:min": "yarn run webpack --env.production --env.target=mobile",
+    "build:development": "yarn run webpack",
+    "build:production": "yarn run webpack --env.production",
     "watch": "yarn run webpack --watch --display-chunks",
-    "watch:mobile": "yarn run watch --env.target=mobile",
     "clean": "rm -rf ./dist/*",
     "lint": "eslint '{config,src,examples,test}/**/*.{js,jsx}'",
     "prebuild": "npm-run-all lint clean tx",
@@ -155,7 +152,6 @@
     ],
     "globals": {
       "__ALLOW_HTTP__": false,
-      "__TARGET__": "browser",
       "__SENTRY_TOKEN__": "token",
       "__DEVELOPMENT__": false,
       "__VERSION__": "4.5.0"

--- a/src/components/Settings/SettingsContent.jsx
+++ b/src/components/Settings/SettingsContent.jsx
@@ -1,4 +1,3 @@
-/* global __TARGET__ */
 import React from 'react'
 
 import { translate } from 'cozy-ui/react/I18n'
@@ -15,96 +14,99 @@ const Settings = ({
   isDrawer = false,
   isClaudyLoading,
   toggleSupport
-}) => (
-  <div className="coz-nav-pop-content">
-    {isDrawer && <hr />}
-    {settingsAppURL && (
+}) => {
+  const isNativeMobile = window.cordova
+  return (
+    <div className="coz-nav-pop-content">
+      {isDrawer && <hr />}
+      {settingsAppURL && (
+        <ul className="coz-nav-group">
+          <li className="coz-nav-settings-item">
+            <a
+              role="menuitem"
+              href={`${settingsAppURL}#/profile`}
+              target="_self"
+              data-icon="icon-profile"
+              title={t('profile')}
+            >
+              <p className="coz-label">{t('profile')}</p>
+            </a>
+          </li>
+          <li className="coz-nav-settings-item">
+            <a
+              role="menuitem"
+              href={`${settingsAppURL}#/connectedDevices`}
+              target="_self"
+              data-icon="icon-connectedDevices"
+              title={t('connectedDevices')}
+            >
+              <p className="coz-label">{t('connectedDevices')}</p>
+            </a>
+          </li>
+        </ul>
+      )}
+      {isDrawer && onClaudy && !isNativeMobile && (
+        <ul className="coz-nav-group">
+          <li className="coz-nav-settings-item">
+            <Button
+              type="button"
+              role="menuitem"
+              className="coz-nav-settings-item-btn"
+              icon="cozy-negative"
+              busy={isClaudyLoading}
+              onClick={onClaudy}
+              title={t('claudy.title')}
+              label={t('claudy.title')}
+            />
+          </li>
+        </ul>
+      )}
+      {!isDrawer && storageData && (
+        <ul className="coz-nav-group">
+          <li className="coz-nav-settings-item">
+            <a
+              role="menuitem"
+              data-icon="icon-storage"
+              target="_self"
+              title={t('storage')}
+              href={`${settingsAppURL}#/storage`}
+            >
+              {t('storage')}
+              <StorageData data={storageData} />
+            </a>
+          </li>
+        </ul>
+      )}
+      {!isNativeMobile && (
+        <ul className="coz-nav-group">
+          <li className="coz-nav-settings-item">
+            <Button
+              type="button"
+              role="menuitem"
+              className="coz-nav-settings-item-btn"
+              onClick={toggleSupport}
+              icon="help"
+              title={t('help')}
+              label={t('help')}
+            />
+          </li>
+        </ul>
+      )}
       <ul className="coz-nav-group">
         <li className="coz-nav-settings-item">
-          <a
-            role="menuitem"
-            href={`${settingsAppURL}#/profile`}
-            target="_self"
-            data-icon="icon-profile"
-            title={t('profile')}
-          >
-            <p className="coz-label">{t('profile')}</p>
-          </a>
-        </li>
-        <li className="coz-nav-settings-item">
-          <a
-            role="menuitem"
-            href={`${settingsAppURL}#/connectedDevices`}
-            target="_self"
-            data-icon="icon-connectedDevices"
-            title={t('connectedDevices')}
-          >
-            <p className="coz-label">{t('connectedDevices')}</p>
-          </a>
-        </li>
-      </ul>
-    )}
-    {isDrawer && onClaudy && __TARGET__ !== 'mobile' && (
-      <ul className="coz-nav-group">
-        <li className="coz-nav-settings-item">
-          <Button
+          <button
             type="button"
             role="menuitem"
-            className="coz-nav-settings-item-btn"
-            icon="cozy-negative"
-            busy={isClaudyLoading}
-            onClick={onClaudy}
-            title={t('claudy.title')}
-            label={t('claudy.title')}
-          />
-        </li>
-      </ul>
-    )}
-    {!isDrawer && storageData && (
-      <ul className="coz-nav-group">
-        <li className="coz-nav-settings-item">
-          <a
-            role="menuitem"
-            data-icon="icon-storage"
-            target="_self"
-            title={t('storage')}
-            href={`${settingsAppURL}#/storage`}
+            data-icon="icon-logout"
+            onClick={onLogOut}
+            title={t('logout')}
           >
-            {t('storage')}
-            <StorageData data={storageData} />
-          </a>
+            {t('logout')}
+          </button>
         </li>
       </ul>
-    )}
-    {__TARGET__ !== 'mobile' && (
-      <ul className="coz-nav-group">
-        <li className="coz-nav-settings-item">
-          <Button
-            type="button"
-            role="menuitem"
-            className="coz-nav-settings-item-btn"
-            onClick={toggleSupport}
-            icon="help"
-            title={t('help')}
-            label={t('help')}
-          />
-        </li>
-      </ul>
-    )}
-    <ul className="coz-nav-group">
-      <li className="coz-nav-settings-item">
-        <button
-          type="button"
-          role="menuitem"
-          data-icon="icon-logout"
-          onClick={onLogOut}
-          title={t('logout')}
-        >
-          {t('logout')}
-        </button>
-      </li>
-    </ul>
-  </div>
-)
+    </div>
+  )
+}
 
 export default translate()(Settings)

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-/* global __TARGET__, __VERSION__ */
+/* global __VERSION__ */
 
 'use strict'
 
@@ -22,10 +22,11 @@ require('lib/importIcons')
 const APP_SELECTOR = '[role=application]'
 
 const createBarElement = () => {
+  const target = window.cordova ? 'mobile' : 'browser'
   const barNode = document.createElement('div')
   barNode.setAttribute('id', 'coz-bar')
   barNode.setAttribute('role', 'banner')
-  barNode.classList.add(`coz-target--${__TARGET__}`)
+  barNode.classList.add(`coz-target--${target}`)
   return barNode
 }
 

--- a/src/lib/stack-client.js
+++ b/src/lib/stack-client.js
@@ -1,4 +1,3 @@
-/* global __TARGET__ */
 /* eslint-env browser */
 
 import { Intents } from 'cozy-interapp'
@@ -286,7 +285,7 @@ const iconFetcher = function(iconPath) {
  * @returns {Object}
  */
 const getAppIconProps = function() {
-  const isMobile = __TARGET__ === 'mobile'
+  const isMobile = window.cordova
 
   const mobileAppIconProps = {
     fetchIcon: app => getIcon(iconFetcher, app, true)

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,4 +1,3 @@
-@import '~cozy-ui/react/stylesheet.css'
 @import '~styles/base.css'
 @import '~styles/indicators.css'
 @import '~styles/bar.css'
@@ -14,15 +13,7 @@
 @import '~styles/supportModal.css'
 
 @import '~styles/theme.styl'
-
-@import 'settings/palette'
-@import 'settings/z-index'
-@import 'tools/mixins'
 @import 'utilities/display'
-@import 'utilities/position'
-@import 'utilities/dimensions'
-
-@import 'components/button.styl'
 
 :root {
   --z-index-bar: $bar-index;

--- a/test/components/AppItem.spec.jsx
+++ b/test/components/AppItem.spec.jsx
@@ -9,7 +9,7 @@ jest.useFakeTimers()
 jest.mock('lib/stack', () => ({
   get: {
     iconProps: () => {
-      return global.__TARGET__ === 'mobile'
+      return window.cordova
         ? { fetchIcon: jest.fn().mockResolvedValue('http://urlOfIcon') }
         : {
             // we mustn't give the protocol here
@@ -62,7 +62,6 @@ describe('app icon', () => {
   let spyConsoleError
 
   beforeEach(() => {
-    global.__TARGET__ = 'browser'
     spyConsoleError = jest.spyOn(console, 'error')
 
     isMobileApp.mockReturnValue(false)
@@ -84,9 +83,13 @@ describe('app icon', () => {
     expect(toJson(root)).toMatchSnapshot()
   })
 
-  it('should render correctly with target mobile and providing fetchIcon to AppIcon', () => {
-    global.__TARGET__ = 'mobile'
-    const root = mount(<AppItem t={tMock} app={app} />)
-    expect(toJson(root)).toMatchSnapshot()
+  it('should render correctly with cordova and providing fetchIcon to AppIcon', () => {
+    window.cordova = {}
+    try {
+      const root = mount(<AppItem t={tMock} app={app} />)
+      expect(toJson(root)).toMatchSnapshot()
+    } finally {
+      delete window.cordova
+    }
   })
 })

--- a/test/lib/stack-client/stack-client.appiconprops.spec.js
+++ b/test/lib/stack-client/stack-client.appiconprops.spec.js
@@ -1,8 +1,6 @@
 import CozyClient from 'cozy-client'
 import stack from 'lib/stack-client'
 
-let oldTarget
-
 describe('stack client', () => {
   describe('getAppIconProps', () => {
     const stackClient = {
@@ -21,18 +19,16 @@ describe('stack client', () => {
     }
 
     beforeAll(async () => {
-      oldTarget = global.__TARGET__
       await stack.init(params)
     })
 
     afterAll(() => {
       jest.restoreAllMocks()
-      global.__TARGET__ = oldTarget
     })
 
     describe('for target=browser', () => {
       beforeAll(() => {
-        global.__TARGET__ = 'browser'
+        window.cordova = null
       })
 
       it('should have `domain` and `secure` set', () => {
@@ -49,7 +45,7 @@ describe('stack client', () => {
 
     describe('for target=mobile', () => {
       beforeAll(() => {
-        global.__TARGET__ = 'mobile'
+        window.cordova = {}
       })
 
       it('should note have `domain` and `secure` set', () => {


### PR DESCRIPTION
I am exploring what should we do to 

- diminish the size of the bar
- prevent integration surprise due to CSS order

Here are some leads:

### 1. Bar can use the same CSS stylesheet as the app

For this Cozy UI should not be transpiled with hashes. This way
the UI classes used in the bar should be the same as the app.

#### Benefits

  * Less integration surprise since there is only one stylesheet.
  * Since there is only one stylesheet, the overall JS/CSS served is less

#### Risks

  * The bar cannot use newer features from cozy-ui since it needs to rely
    on features that are available on all apps. In practice I think it will
    force us to keep cozy-ui up-to-date in our apps. 

#### Steps

1. Cozy UI stylesheet should be transpiled without hashes : https://github.com/cozy/cozy-ui/pull/1029
2. Update UI in banks / bar
3. Remove automatic importing of cozy-ui stylesheet in the bar https://github.com/cozy/cozy-bar/pull/580/commits/9221b9631a3b1d30b33b14f2fb0b2d5e11d20992

### 2. Lighter bundle without React and React dom

We can use webpack external feature to tell webpack that some dependencies should be provided by the
app via window.

This bundle could be used by apps using React / ReactDOM through a special asset cozy-bar.light.js

https://github.com/cozy/cozy-bar/pull/580/commits/7307bfe09d480a3d4108c27543f094046c75abc8

### 3. Bar no longer served by the stack

In web and mobile, same process, the bar is a dependency that should be updated and is no longer
served by the stack.

In practice the bar has to be updated in the apps because the native apps have no stack so it is will
only streamline the process between web / mobile. In this vein I have made an attempt at removing
the multibuild (target = browser or mobile) for the bar. I think it is an unnecessary complication
since window.cordova can be used to see if we are on native.

https://github.com/cozy/cozy-bar/pull/580/commits/c5a695403d5b11c36097d7c34b9c77aa9e406a48