### PR TITLE
fix: Avoid cozy-ui stylesheet conflict with the apps

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -14,7 +14,7 @@ module.exports = {
     umdNamedDefine: true
   },
   resolve: {
-    extensions: ['.js', '.json', '.yaml'],
+    extensions: ['.js', '.json', '.yaml', '.jsx'],
     modules: [SRC_DIR, 'node_modules'],
     alias: {
       react: path.resolve(__dirname, 'aliases/globalReact'),
@@ -25,8 +25,11 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        exclude: /node_modules/,
+        test: /\.jsx?$/,
+        include: [
+          path.resolve(__dirname, '../src'),
+          path.dirname(require.resolve('cozy-ui'))
+        ],
         loader: 'babel-loader'
       },
       {

--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -18,8 +18,7 @@ module.exports = {
     modules: [SRC_DIR, 'node_modules'],
     alias: {
       react: path.resolve(__dirname, 'aliases/globalReact'),
-      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM'),
-      'cozy-ui/react': 'cozy-ui/transpiled/react'
+      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM')
     }
   },
   devtool: '#source-map',

--- a/config/webpack.config.extract.js
+++ b/config/webpack.config.extract.js
@@ -45,7 +45,7 @@ module.exports = ({ filename, production }) => ({
               importLoaders: 2,
               sourceMap: true,
               modules: true,
-              localIdentName: '[local]--[hash: base64:5]'
+              localIdentName: 'cozy-ui-bar-[local]--[hash:base64:5]'
             }
           },
           {

--- a/config/webpack.config.extract.js
+++ b/config/webpack.config.extract.js
@@ -16,7 +16,7 @@ module.exports = ({ filename, production }) => ({
           MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
-            options: { importLoaders: 1, sourceMap: true }
+            options: { importLoaders: 2, sourceMap: true }
           },
           {
             loader: 'postcss-loader',
@@ -42,7 +42,7 @@ module.exports = ({ filename, production }) => ({
           {
             loader: 'css-loader',
             options: {
-              importLoaders: 1,
+              importLoaders: 2,
               sourceMap: true,
               modules: true,
               localIdentName: '[local]--[hash: base64:5]'

--- a/config/webpack.config.inline-styles.js
+++ b/config/webpack.config.inline-styles.js
@@ -17,7 +17,7 @@ module.exports = ({ production }) => ({
           },
           {
             loader: 'css-loader',
-            options: { importLoaders: 1, sourceMap: true }
+            options: { importLoaders: 2, sourceMap: true }
           },
           {
             loader: 'postcss-loader',

--- a/config/webpack.config.jsx.js
+++ b/config/webpack.config.jsx.js
@@ -3,18 +3,6 @@
 const webpack = require('webpack')
 
 module.exports = {
-  resolve: {
-    extensions: ['.jsx']
-  },
-  module: {
-    rules: [
-      {
-        test: /\.jsx$/,
-        exclude: /node_modules\/(?!(cozy-ui))/,
-        loader: 'babel-loader'
-      }
-    ]
-  },
   // Necessary for cozy-ui during Preact -> React apps transition
   plugins: [
     new webpack.DefinePlugin({

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,4 +1,3 @@
-@import '~cozy-ui/react/stylesheet.css'
 @import '~styles/base.css'
 @import '~styles/indicators.css'
 @import '~styles/bar.css'


### PR DESCRIPTION
This PR goal is to fix the bugs we have when we use a cozy-bar with a cozy-ui version that is not the same as the host app cozy-ui version.

This problems exists because the cozy-bar uses the transpiled version of cozy-ui, thus we could have two stylesheets that could override each other.

The solution explored here is to stop using the transpiled version of cozy-ui. The bar transpiles its own cozy-ui and use a custom classname scheme for cozy-ui's classnames. This way, there is no more conflicts between the bar's cozy-ui stylesheets and app's cozy-ui stylesheet.

This was tested on Banks, in which we had this issue: they are all gone.