### PR TITLE
Go back to config excluding node_modules

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -26,10 +26,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        include: [
-          path.resolve(__dirname, '../src'),
-          path.dirname(require.resolve('cozy-ui'))
-        ],
+        exclude: /node_modules\/(?!(cozy-ui\/react))/,
         loader: 'babel-loader'
       },
       {


### PR DESCRIPTION
The goal of this PR is to go back using an `exclude` clause. It will allow custom repositories to transpile override directories.