### PR TITLE
Revert "fix: Avoid cozy-ui stylesheet conflict with the apps"

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -14,19 +14,20 @@ module.exports = {
     umdNamedDefine: true
   },
   resolve: {
-    extensions: ['.js', '.json', '.yaml', '.jsx'],
+    extensions: ['.js', '.json', '.yaml'],
     modules: [SRC_DIR, 'node_modules'],
     alias: {
       react: path.resolve(__dirname, 'aliases/globalReact'),
-      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM')
+      'react-dom': path.resolve(__dirname, 'aliases/globalReactDOM'),
+      'cozy-ui/react': 'cozy-ui/transpiled/react'
     }
   },
   devtool: '#source-map',
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
-        exclude: /node_modules\/(?!(cozy-ui\/react))/,
+        test: /\.js$/,
+        exclude: /node_modules/,
         loader: 'babel-loader'
       },
       {

--- a/config/webpack.config.extract.js
+++ b/config/webpack.config.extract.js
@@ -16,7 +16,7 @@ module.exports = ({ filename, production }) => ({
           MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
-            options: { importLoaders: 2, sourceMap: true }
+            options: { importLoaders: 1, sourceMap: true }
           },
           {
             loader: 'postcss-loader',
@@ -42,10 +42,10 @@ module.exports = ({ filename, production }) => ({
           {
             loader: 'css-loader',
             options: {
-              importLoaders: 2,
+              importLoaders: 1,
               sourceMap: true,
               modules: true,
-              localIdentName: 'cozy-ui-bar-[local]--[hash:base64:5]'
+              localIdentName: '[local]--[hash: base64:5]'
             }
           },
           {

--- a/config/webpack.config.inline-styles.js
+++ b/config/webpack.config.inline-styles.js
@@ -17,7 +17,7 @@ module.exports = ({ production }) => ({
           },
           {
             loader: 'css-loader',
-            options: { importLoaders: 2, sourceMap: true }
+            options: { importLoaders: 1, sourceMap: true }
           },
           {
             loader: 'postcss-loader',

--- a/config/webpack.config.jsx.js
+++ b/config/webpack.config.jsx.js
@@ -3,6 +3,18 @@
 const webpack = require('webpack')
 
 module.exports = {
+  resolve: {
+    extensions: ['.jsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx$/,
+        exclude: /node_modules\/(?!(cozy-ui))/,
+        loader: 'babel-loader'
+      }
+    ]
+  },
   // Necessary for cozy-ui during Preact -> React apps transition
   plugins: [
     new webpack.DefinePlugin({

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,3 +1,4 @@
+@import '~cozy-ui/react/stylesheet.css'
 @import '~styles/base.css'
 @import '~styles/indicators.css'
 @import '~styles/bar.css'


### PR DESCRIPTION
This reverts commit ff86f9b939950a3832be8f041f3c52168fee009c.

We had troubles with the update of the webpack config to bundle not transpiled cozy-ui. Related: https://github.com/cozy/cozy-bar/pull/582

I think the plan could be to revert these changes in master and npm's `latest` channel, then do it in a branch and the npm's `next` channel.