### PR TITLE
AppItem: Prevent malformed URL to make the app crash

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -30,7 +30,14 @@ export class AppItem extends React.Component {
   }
 
   buildAppUrl(href) {
-    const url = new URL(href)
+    let url
+    try {
+      url = new URL(href)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error.message)
+      return null
+    }
     const queryParams = AppItem.buildQueryParams(this.props, this.context)
     if (queryParams) {
       for (const name in queryParams) {
@@ -58,7 +65,7 @@ export class AppItem extends React.Component {
       <AppLinker
         onAppSwitch={this.onAppSwitch}
         slug={app.slug}
-        href={this.buildAppUrl(app.href)}
+        href={this.buildAppUrl(app.href) || ''}
       >
         {({ onClick, href }) => {
           const label = t(`${app.slug}.name`, {

--- a/test/components/AppItem.spec.jsx
+++ b/test/components/AppItem.spec.jsx
@@ -56,6 +56,19 @@ describe('AppItem', () => {
       const url = wrapper.instance().buildAppUrl('http://fake.fr')
       expect(url).toBe('http://fake.fr/?foo=bar&bar=buz')
     })
+
+    it('should return null for invalid url', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      const invalidApp = {
+        name: 'Invalid app',
+        url: 'Clearly not an url',
+        slug: 'invalid-app'
+      }
+      const wrapper = shallow(<AppItem app={invalidApp} t={tMock} />)
+      const appLinkerWrapper = wrapper.find('AppLinker')
+      expect(appLinkerWrapper.props().href).toEqual('')
+    })
   })
 })
 


### PR DESCRIPTION
~~When serving an app locally with option `--appdir`, the app is listed in the endpoint `/apps/` but all fields are `undefined`.~~

If a document has been created by mistake in DB `io.cozy.apps`, it is returned in the `/apps/` endpoint response with all its fields being `undefined`.

This PR ensure that an `undefined` href will not make the whole app to crash when building the app url.