### PR TITLE
fix: Avoid FOUC on mobile

### DIFF
--- a/config/webpack.config.inline-styles.js
+++ b/config/webpack.config.inline-styles.js
@@ -12,12 +12,11 @@ module.exports = ({ production }) => ({
         test: /\.styl$/,
         use: [
           {
-            loader: 'style-loader',
-            options: { sourceMap: true }
+            loader: 'style-loader'
           },
           {
             loader: 'css-loader',
-            options: { importLoaders: 1, sourceMap: true }
+            options: { importLoaders: 1 }
           },
           {
             loader: 'postcss-loader',


### PR DESCRIPTION
When sourcemap is enabled in css-loader, the style-loader injects a
`link` tag pointing to a blob generated dynamically. This leads to a
flash of unstyled content (FOUC) on the bar. Disabling the sourcemap
makes the style-loader inject a `style` tag and we don't have a FOUC
anymore.