### PR TITLE
chore: Remove console warnings

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -237,6 +237,7 @@ class SearchBar extends Component {
       const url = onSelect.substr(5)
       window.location.href = url
     } else {
+      // eslint-disable-next-line no-console
       console.log(
         'suggestion onSelect (' + onSelect + ') could not be executed'
       )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -47,6 +47,7 @@ const injectBarInDOM = data => {
   const barNode = createBarElement()
   const appNode = document.querySelector(APP_SELECTOR)
   if (!appNode) {
+    // eslint-disable-next-line no-console
     console.warn(
       `Cozy-bar is looking for a "${APP_SELECTOR}" tag that contains your application and can't find it :'(… The BAR is now disabled`
     )
@@ -101,6 +102,7 @@ const getDefaultStackURL = isPublic => {
   const data = getAppNodeDataSet()
   if (!data.cozyDomain) {
     if (!isPublic) {
+      // eslint-disable-next-line no-console
       console.warn(
         `Cozy-bar can't discover the cozy's URL, and will probably fail to initialize the connection with the stack.`
       )
@@ -116,6 +118,7 @@ const getDefaultToken = isPublic => {
   const data = getAppNodeDataSet()
   if (!data.cozyToken) {
     if (!isPublic) {
+      // eslint-disable-next-line no-console
       console.warn(
         `Cozy-bar can't discover the app's token, and will probably fail to initialize the connection with the stack.`
       )
@@ -206,6 +209,7 @@ const init = async ({
       uri: ccURI,
       token: ccToken
     }
+    // eslint-disable-next-line no-console
     console.warn('Automatically made cozyClient. Options: ', ccOptions)
     const CozyClient = require('cozy-client').default
     cozyClient = new CozyClient({})
@@ -252,10 +256,12 @@ const updateAccessToken = accessToken => {
 }
 
 // Handle exceptions for API before init
-const showAPIError = name =>
+const showAPIError = name => {
+  // eslint-disable-next-line no-console
   console.error(
     `You tried to use the CozyBar API (${name}) but the CozyBar is not initialised yet via cozy.bar.init(...).`
   )
+}
 // apiReferences will be a proxy to the API
 const apiReferences = {}
 

--- a/src/lib/realtime.js
+++ b/src/lib/realtime.js
@@ -35,6 +35,7 @@ function initializeRealtime({ getApp, onCreate, onDelete, cozyClient }) {
     realtime.subscribe('created', APPS_DOCTYPE, handleAppCreation)
     realtime.subscribe('deleted', APPS_DOCTYPE, handleAppRemoval)
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.warn(`Cannot initialize realtime in Cozy-bar: ${error.message}`)
   }
 }

--- a/src/lib/reducers/apps.js
+++ b/src/lib/reducers/apps.js
@@ -56,6 +56,7 @@ export const fetchApps = () => async dispatch => {
     await dispatch(receiveAppList(apps))
   } catch (e) {
     dispatch({ type: FETCH_APPS_FAILURE })
+    // eslint-disable-next-line no-console
     console.warn(e.message ? e.message : e)
   }
 }
@@ -76,8 +77,8 @@ const setHomeApp = appsList => async dispatch => {
       return dispatch(receiveHomeApp(homeApp))
     })
     .catch(error => {
-      console.warn &&
-        console.warn(`Cozy-bar cannot fetch home app data: ${error.message}`)
+      // eslint-disable-next-line no-console
+      console.warn(`Cozy-bar cannot fetch home app data: ${error.message}`)
       return appsList
     })
 }

--- a/src/lib/reducers/context.js
+++ b/src/lib/reducers/context.js
@@ -32,7 +32,8 @@ export const fetchContext = () => async (dispatch, getState) => {
     if (error.status && error.status === 404) {
       dispatch({ type: RECEIVE_NO_CONTEXT })
     }
-    console.warn && console.warn('Cannot get Cozy context')
+    // eslint-disable-next-line no-console
+    console.warn('Cannot get Cozy context')
     return null
   }
 }

--- a/src/lib/reducers/settings.js
+++ b/src/lib/reducers/settings.js
@@ -31,6 +31,7 @@ const fetchStorageData = () => async dispatch => {
     const storageData = await stack.get.storageData()
     return dispatch({ type: RECEIVE_STORAGE, storageData })
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn && console.warn('Cannot get Cozy storage informations')
     return null
   }
@@ -48,8 +49,8 @@ const fetchSettingsAppURL = () => async (dispatch, getState) => {
     const settingsAppURL = await stack.get.settingsAppURL()
     return dispatch({ type: RECEIVE_SETTINGS_URL, settingsAppURL })
   } catch (e) {
-    console.warn &&
-      console.warn('Settings app is unavailable, settings links are disabled')
+    // eslint-disable-next-line no-console
+    console.warn('Settings app is unavailable, settings links are disabled')
     return null
   }
 }
@@ -72,6 +73,7 @@ export const logOut = () => async dispatch => {
   try {
     await stack.logout()
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn('Error while logging out in the cozy-bar', e)
   }
 }


### PR DESCRIPTION
We should not have any eslint warnings. I disabled the warnings via `eslint-disable-next-line no-console`.
There were also occurences of `console.log && console.log('my log')` that I do not think are necessary. Do
you have any idea @gregorylegarec why the call needed a check ?