### PR TITLE
fix: Change iframe visibility

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -323,7 +323,11 @@ class SearchBar extends Component {
     return (
       <div className="coz-searchbar" role="search">
         {sourceURLs.map((url, i) => (
-          <iframe src={url} style={{ display: 'none' }} key={url + i} />
+          <iframe
+            src={url}
+            style={{ visibility: 'hidden', height: '0px', width: '0px' }}
+            key={url + i}
+          />
         ))}
         <Autosuggest
           theme={theme}


### PR DESCRIPTION
We can have MUI component loaded inside an iframe. It works
pretty well on Chromium and Safari, but not on Firefox
'cauz of this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=548397

Our CozyMUITheme is based on getComputedStyle, but since the iframe
is hidden, firefox crash during its creation.

The workaround is to not use display:none, but instead visibility
hidden with height & width = 0

(Our bug case was the searchbar on Drive)