### PR TITLE
feat: Display view offers buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-runtime": "6.26.0",
     "bundlesize": "0.18.0",
     "cozy-authentication": "1.19.1",
-    "cozy-client": "6.66.0",
+    "cozy-client": "8.1.0",
     "css-loader": "1.0.1",
     "css-mqpacker": "7.0.0",
     "cssnano-preset-advanced": "4.0.7",

--- a/src/components/Settings/SettingsContent.jsx
+++ b/src/components/Settings/SettingsContent.jsx
@@ -85,7 +85,6 @@ const SettingsContent = ({
             subtle
             role="menuitem"
             className="coz-nav-settings-item-btn"
-            //onClick={toggleSupport}
             icon="cloud-happy"
             title={t('view_offers')}
             label={t('view_offers')}

--- a/src/components/Settings/SettingsContent.jsx
+++ b/src/components/Settings/SettingsContent.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { translate } from 'cozy-ui/react/I18n'
-import { Button } from 'cozy-ui/react/Button'
+import { Button, ButtonLink } from 'cozy-ui/react/Button'
 import { isMobileApp } from 'cozy-device-helper'
 import StorageData from 'components/Settings/StorageData'
 
-const Settings = ({
+const SettingsContent = ({
   t,
   onLogOut,
   settingsAppURL,
@@ -13,7 +14,9 @@ const Settings = ({
   onClaudy,
   isDrawer = false,
   isClaudyLoading,
-  toggleSupport
+  toggleSupport,
+  shoulDisplayViewOfferButton,
+  managerUrlPremiumLink
 }) => (
   <div className="coz-nav-pop-content">
     {isDrawer && <hr />}
@@ -75,6 +78,23 @@ const Settings = ({
         </li>
       </ul>
     )}
+    {(!isDrawer || !isMobileApp()) && shoulDisplayViewOfferButton && (
+      <ul className="coz-nav-group">
+        <li className="coz-nav-settings-item">
+          <ButtonLink
+            subtle
+            role="menuitem"
+            className="coz-nav-settings-item-btn"
+            //onClick={toggleSupport}
+            icon="cloud-happy"
+            title={t('view_offers')}
+            label={t('view_offers')}
+            href={managerUrlPremiumLink}
+          />
+        </li>
+      </ul>
+    )}
+
     {!isMobileApp() && (
       <ul className="coz-nav-group">
         <li className="coz-nav-settings-item">
@@ -106,4 +126,19 @@ const Settings = ({
   </div>
 )
 
-export default translate()(Settings)
+SettingsContent.defaultProps = {
+  shoulDisplayViewOfferButton: false
+}
+
+SettingsContent.propTypes = {
+  shoulDisplayViewOfferButton: PropTypes.bool,
+  t: PropTypes.func.isRequired,
+  onLogOut: PropTypes.func.isRequired,
+  settingsAppURL: PropTypes.string,
+  storageData: PropTypes.object,
+  onClaudy: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  isDrawer: PropTypes.bool,
+  isClaudyLoading: PropTypes.bool,
+  toggleSupport: PropTypes.func.isRequired
+}
+export default translate()(SettingsContent)

--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -1,0 +1,3 @@
+export const isFetching = requests => {
+  return requests.some(request => request.fetchStatus === 'loading')
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "connectedDevices": "Connected devices",
   "storage": "Storage",
   "storage_phrase": "%{diskUsage} GB of %{diskQuota} GB used",
+  "view_offers": "View offers",
   "help": "Help",
   "logout": "Sign out",
   "soon": "soon",

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,20 @@
+export const instanceReq = {
+  query: client => {
+    return client.get('io.cozy.settings', 'instance')
+  },
+  as: 'instanceQuery'
+}
+
+export const contextReq = {
+  query: client => {
+    return client.get('io.cozy.settings', 'context')
+  },
+  as: 'contextQuery'
+}
+
+export const diskUsageReq = {
+  query: client => {
+    return client.get('io.cozy.settings', 'disk-usage')
+  },
+  as: 'diskUsageQuery'
+}

--- a/test/components/Settings/helper.spec.js
+++ b/test/components/Settings/helper.spec.js
@@ -1,0 +1,23 @@
+import { isFetching } from 'components/Settings/helper'
+
+describe('Settings Helper', () => {
+  it('should return true if isFetching', () => {
+    const fakeRequest1 = {
+      fetchStatus: 'loading'
+    }
+    const fakeRequest2 = {
+      fetchStatus: 'loaded'
+    }
+    expect(isFetching([fakeRequest1, fakeRequest2])).toBe(true)
+  })
+
+  it('should not return true if not fetching', () => {
+    const fakeRequest1 = {
+      fetchStatus: 'loaded'
+    }
+    const fakeRequest2 = {
+      fetchStatus: 'loaded'
+    }
+    expect(isFetching([fakeRequest1, fakeRequest2])).toBe(false)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,13 +4428,13 @@ cozy-authentication@1.19.1:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-client@6.66.0:
-  version "6.66.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.66.0.tgz#a7e277fc4b893e85275e60b445307cb30cc332ad"
-  integrity sha512-x//RAptC5zyt93tPd43I6SukepMWZFj9b11VpXCxxH+0aWLryQwlNRrrElkIcoze2Cn0XlmUg2DDoyvUuB2SwQ==
+cozy-client@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.1.0.tgz#3dbaa6e6454241f186e8b242990129f4a22d3334"
+  integrity sha512-Xy4cpxTIdu1jVUetgd6aG+n4qgYKqhXTkxnSq/OPt+Px8kS1XH3aQMqPT/bBb81sM5RGz1qtkPP8H9SHBbNo6g==
   dependencies:
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^6.66.0"
+    cozy-stack-client "^8.0.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     prop-types "^15.6.2"
@@ -4463,10 +4463,10 @@ cozy-realtime@3.2.1:
   dependencies:
     minilog "3.1.0"
 
-cozy-stack-client@^6.66.0:
-  version "6.66.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.66.0.tgz#ba217c2d615dd31a9f40ae131644c68c4108b101"
-  integrity sha512-NPdoDplH43nLBlTXVXYCOutRkh3Q+Dib92BGU8F3PanCMjCBXiRUni6I7EhcumwJkXeJVm7qul72X4LYKlOzgA==
+cozy-stack-client@^8.0.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-7.12.0.tgz#9a5df9fa77730d04cf1a31c1e5db9c931c8db94d"
+  integrity sha512-ld0/Hm4F9HGjGESEg/QbO71cRFslprxo4EZ4bWKhm5gi1iMeUnOBeDHSTI36iI+xs4ouZTvf9KxTcnkchKG8Cw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4464,9 +4464,9 @@ cozy-realtime@3.2.1:
     minilog "3.1.0"
 
 cozy-stack-client@^8.0.0:
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-7.12.0.tgz#9a5df9fa77730d04cf1a31c1e5db9c931c8db94d"
-  integrity sha512-ld0/Hm4F9HGjGESEg/QbO71cRFslprxo4EZ4bWKhm5gi1iMeUnOBeDHSTI36iI+xs4ouZTvf9KxTcnkchKG8Cw==
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-8.0.0.tgz#1c0d69b3b5261ba383ae2b2c293bd74b07b28bdf"
+  integrity sha512-Kawi0Qc9NedVQyCq8CHePRdxYHQlKrHfNQqZZoNZroma/NlxTB1kvhAbwh/UDuVx+jF1wh3PnDRdivKBdILVeQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
- Display a button if the cozy is concerned by a Premium offer 
- Use cozy-client and queryConnect to get the infos 


I think we do sometimes the request from old code but also from this new one, but I think I'll be easier to migrate the old code in this way and old code set stuff in the redux store and I didn't want to create a too big refacto for now. 

Let's do that in the future work :) 