### PR TITLE
feat: Check cozyclient version to call instance info

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-runtime": "6.26.0",
     "bundlesize": "0.18.0",
     "cozy-authentication": "1.19.1",
-    "cozy-client": "^8.3.1",
+    "cozy-client": "8.3.1",
     "css-loader": "1.0.1",
     "css-mqpacker": "7.0.0",
     "cssnano-preset-advanced": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-runtime": "6.26.0",
     "bundlesize": "0.18.0",
     "cozy-authentication": "1.19.1",
-    "cozy-client": "8.1.0",
+    "cozy-client": "^8.3.1",
     "css-loader": "1.0.1",
     "css-mqpacker": "7.0.0",
     "cssnano-preset-advanced": "4.0.7",
@@ -112,7 +112,8 @@
     "react-redux": "5.1.1",
     "redux": "3.7.2",
     "redux-persist": "5.10.0",
-    "redux-thunk": "2.3.0"
+    "redux-thunk": "2.3.0",
+    "semver-compare": "^1.0.0"
   },
   "peerDependencies": {
     "cozy-client": "*"

--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -1,3 +1,12 @@
-export const isFetching = requests => {
+import CozyClient from 'cozy-client'
+import compare from 'semver-compare'
+
+export const isFetchingQueries = requests => {
   return requests.some(request => request.fetchStatus === 'loading')
+}
+
+export const cozyClientCanCheckPremium = () => {
+  if (!CozyClient.version) return false
+  const result = compare(CozyClient.version, '8.3.0')
+  return result >= 0
 }

--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -5,8 +5,10 @@ export const isFetchingQueries = requests => {
   return requests.some(request => request.fetchStatus === 'loading')
 }
 
-export const cozyClientCanCheckPremium = () => {
-  if (!CozyClient.version) return false
-  const result = compare(CozyClient.version, '8.3.0')
+export const cozyClientCanCheckPremium = (forcedCozyClient = null) => {
+  const cozyClientToUse =
+    forcedCozyClient !== null ? forcedCozyClient : CozyClient
+  if (!cozyClientToUse.version) return false
+  const result = compare(cozyClientToUse.version, '8.3.0')
   return result >= 0
 }

--- a/src/components/Settings/index.jsx
+++ b/src/components/Settings/index.jsx
@@ -73,7 +73,7 @@ export class Settings extends Component {
       isFetching
     } = this.props
 
-    let shoulDisplayViewOfferButton = false
+    let shouldDisplayViewOfferButton = false
     let managerUrlPremiumLink
     let isFetchingFromQueries
     const canCheckPremium = cozyClientCanCheckPremium()
@@ -89,20 +89,20 @@ export class Settings extends Component {
           diskUsage: diskUsageQuery,
           instance: instanceQuery
         }
-        shoulDisplayViewOfferButton = instanceModel.shouldDisplayOffers(data)
+        shouldDisplayViewOfferButton = instanceModel.shouldDisplayOffers(data)
         managerUrlPremiumLink = instanceModel.buildPremiumLink(data)
       }
     }
 
-    let isAllFetchingAreDone = false
+    let areAllFetchingDone = false
     if (!canCheckPremium) {
-      isAllFetchingAreDone = !isFetching
+      areAllFetchingDone = !isFetching
     } else {
-      isAllFetchingAreDone = !isFetchingFromQueries && !isFetching
+      areAllFetchingDone = !isFetchingFromQueries && !isFetching
     }
 
     const { opened } = this.state
-    const openMenu = opened && isAllFetchingAreDone
+    const openMenu = opened && areAllFetchingDone
     return (
       <div
         className="coz-nav coz-nav-settings"
@@ -125,7 +125,7 @@ export class Settings extends Component {
           id="coz-nav-pop--settings"
           aria-hidden={!openMenu}
         >
-          {isAllFetchingAreDone && (
+          {areAllFetchingDone && (
             <>
               <SettingsContent
                 onLogOut={() => {
@@ -138,7 +138,7 @@ export class Settings extends Component {
                 toggleSupport={toggleSupport}
                 storageData={storageData}
                 settingsAppURL={settingsAppURL}
-                shoulDisplayViewOfferButton={shoulDisplayViewOfferButton}
+                shoulDisplayViewOfferButton={shouldDisplayViewOfferButton}
                 managerUrlPremiumLink={managerUrlPremiumLink}
               />
             </>

--- a/test/components/Settings/helper.spec.js
+++ b/test/components/Settings/helper.spec.js
@@ -1,14 +1,17 @@
-import { isFetching } from 'components/Settings/helper'
+import {
+  isFetchingQueries,
+  cozyClientCanCheckPremium
+} from 'components/Settings/helper'
 
 describe('Settings Helper', () => {
-  it('should return true if isFetching', () => {
+  it('should return true if isFetchingQueries', () => {
     const fakeRequest1 = {
       fetchStatus: 'loading'
     }
     const fakeRequest2 = {
       fetchStatus: 'loaded'
     }
-    expect(isFetching([fakeRequest1, fakeRequest2])).toBe(true)
+    expect(isFetchingQueries([fakeRequest1, fakeRequest2])).toBe(true)
   })
 
   it('should not return true if not fetching', () => {
@@ -18,6 +21,10 @@ describe('Settings Helper', () => {
     const fakeRequest2 = {
       fetchStatus: 'loaded'
     }
-    expect(isFetching([fakeRequest1, fakeRequest2])).toBe(false)
+    expect(isFetchingQueries([fakeRequest1, fakeRequest2])).toBe(false)
+  })
+
+  it('should return true for cozyClientCanCheckPremium', () => {
+    expect(cozyClientCanCheckPremium()).toBe(true)
   })
 })

--- a/test/components/Settings/helper.spec.js
+++ b/test/components/Settings/helper.spec.js
@@ -25,6 +25,13 @@ describe('Settings Helper', () => {
   })
 
   it('should return true for cozyClientCanCheckPremium', () => {
+    const CozyClient = {
+      version: '6.7.8'
+    }
+
+    expect(cozyClientCanCheckPremium(CozyClient)).toBe(false)
+    expect(cozyClientCanCheckPremium({ version: '10.7.8' })).toBe(true)
+    //we expect the current CozyClient version is OK
     expect(cozyClientCanCheckPremium()).toBe(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,7 +4428,7 @@ cozy-authentication@1.19.1:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-client@^8.3.1:
+cozy-client@8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.3.1.tgz#5e3ef7f9901f91a3e2d820dfff2ef7587c5f8053"
   integrity sha512-Mj6Gt/YIuZ4nmSnnevyCVzgFuYMJrGeSmzo3agmdNNT7rmV8z7DFHSiZNqtYQNfTRY5y3NYWOXRSy7/dt2bC1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,13 +4428,13 @@ cozy-authentication@1.19.1:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-client@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.1.0.tgz#3dbaa6e6454241f186e8b242990129f4a22d3334"
-  integrity sha512-Xy4cpxTIdu1jVUetgd6aG+n4qgYKqhXTkxnSq/OPt+Px8kS1XH3aQMqPT/bBb81sM5RGz1qtkPP8H9SHBbNo6g==
+cozy-client@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-8.3.1.tgz#5e3ef7f9901f91a3e2d820dfff2ef7587c5f8053"
+  integrity sha512-Mj6Gt/YIuZ4nmSnnevyCVzgFuYMJrGeSmzo3agmdNNT7rmV8z7DFHSiZNqtYQNfTRY5y3NYWOXRSy7/dt2bC1A==
   dependencies:
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^8.0.0"
+    cozy-stack-client "^8.3.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     prop-types "^15.6.2"
@@ -4463,10 +4463,10 @@ cozy-realtime@3.2.1:
   dependencies:
     minilog "3.1.0"
 
-cozy-stack-client@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-8.0.0.tgz#1c0d69b3b5261ba383ae2b2c293bd74b07b28bdf"
-  integrity sha512-Kawi0Qc9NedVQyCq8CHePRdxYHQlKrHfNQqZZoNZroma/NlxTB1kvhAbwh/UDuVx+jF1wh3PnDRdivKBdILVeQ==
+cozy-stack-client@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-8.3.0.tgz#fb9d8a7eac0ae8c24ef93b90ee83a7d01389182d"
+  integrity sha512-sxVMtfbePe2iZZYPV+ZxBw+P7mNzcgl7OmOrJxbYqaTkVkJYFKJt/kyrat/XmxAGbKlTviYCh7CMJgQd3I0EBQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -13032,6 +13032,11 @@ semantic-release@15.13.24:
     semver "^6.0.0"
     signale "^1.2.1"
     yargs "^14.0.0"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
check cozyclient version before calling new functions 

Wanted to add a few tests for the component, but it requires more work since enzyme et enzyme react adapter are pretty old. An upgrade breaks other tests... 