### PR TITLE
fix: Better support for old cozyclient version

### DIFF
--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -1,13 +1,25 @@
-import CozyClient from 'cozy-client'
 import compare from 'semver-compare'
-
+import client from 'lib/stack-client'
 export const isFetchingQueries = requests => {
   return requests.some(request => request.fetchStatus === 'loading')
 }
-
+/**
+ *
+ * @param {cozyClient} forcedCozyClient only used to test purpose
+ *
+ * We can not read `version` from `import CozyClient from cozy-client`
+ * since in that case, we'll read version from the cozy-bar node modules
+ * and not from the app one.
+ *
+ * In order to avoid this issue, we get the cozyclient instance from
+ * lib/stack-client (cozyclient's instance passed by the app to the bar),
+ * then read the constructor and then read the version from it
+ */
 export const cozyClientCanCheckPremium = (forcedCozyClient = null) => {
   const cozyClientToUse =
-    forcedCozyClient !== null ? forcedCozyClient : CozyClient
+    forcedCozyClient !== null
+      ? forcedCozyClient
+      : client.getClient().constructor
   if (!cozyClientToUse.version) return false
   const result = compare(cozyClientToUse.version, '8.3.0')
   return result >= 0

--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -16,10 +16,10 @@ export const isFetchingQueries = requests => {
  * then read the constructor and then read the version from it
  */
 export const cozyClientCanCheckPremium = (forcedCozyClient = null) => {
+  const usedClient = client.getClient() ? client.getClient().constructor : {}
   const cozyClientToUse =
-    forcedCozyClient !== null
-      ? forcedCozyClient
-      : client.getClient().constructor
+    forcedCozyClient !== null ? forcedCozyClient : usedClient
+
   if (!cozyClientToUse.version) return false
   const result = compare(cozyClientToUse.version, '8.3.0')
   return result >= 0

--- a/src/components/Settings/index.jsx
+++ b/src/components/Settings/index.jsx
@@ -5,7 +5,11 @@ import { translate } from 'cozy-ui/react/I18n'
 import { Button } from 'cozy-ui/react/Button'
 import { queryConnect } from 'cozy-client/dist'
 import { models } from 'cozy-client'
-const { instance: instanceModel } = models
+let instanceModel = undefined
+if (models) {
+  instanceModel = models.instance
+}
+
 import SettingsContent from 'components/Settings/SettingsContent'
 import {
   fetchSettingsData,
@@ -161,16 +165,27 @@ const mapDispatchToProps = dispatch => ({
   fetchSettingsData: () => dispatch(fetchSettingsData()),
   logOut: () => dispatch(logOut())
 })
-
-export default compose(
-  translate(),
-  queryConnect({
-    instanceQuery: instanceReq,
-    contextQuery: contextReq,
-    diskUsageQuery: diskUsageReq
-  }),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )
-)(Settings)
+let exported
+if (cozyClientCanCheckPremium()) {
+  exported = compose(
+    translate(),
+    queryConnect({
+      instanceQuery: instanceReq,
+      contextQuery: contextReq,
+      diskUsageQuery: diskUsageReq
+    }),
+    connect(
+      mapStateToProps,
+      mapDispatchToProps
+    )
+  )(Settings)
+} else {
+  exported = compose(
+    translate(),
+    connect(
+      mapStateToProps,
+      mapDispatchToProps
+    )
+  )(Settings)
+}
+export default exported

--- a/src/lib/stack-client.js
+++ b/src/lib/stack-client.js
@@ -339,6 +339,10 @@ const getSettingsAppURL = function() {
   })
 }
 
+const getClient = function() {
+  return cozyClient
+}
+
 /**
  * Initializes the functions to call the cozy stack
  *
@@ -374,5 +378,6 @@ export default {
   updateAccessToken,
   cozyFetchJSON,
   logout,
-  init
+  init,
+  getClient
 }

--- a/test/components/Settings/helper.spec.js
+++ b/test/components/Settings/helper.spec.js
@@ -31,7 +31,5 @@ describe('Settings Helper', () => {
 
     expect(cozyClientCanCheckPremium(CozyClient)).toBe(false)
     expect(cozyClientCanCheckPremium({ version: '10.7.8' })).toBe(true)
-    //we expect the current CozyClient version is OK
-    expect(cozyClientCanCheckPremium()).toBe(true)
   })
 })


### PR DESCRIPTION
On old CozyClient version, we can't use queryConnect since we have errors with ObersableQueries. 

In order to avoid that issue, we export the "new component" only if we can checkPremium. (tested on current contact stable) 

Also, we can't read cozyclient's version from the static import of cozy-client. We need to read it from the cozy-client's instance passed to the bar