### PR TITLE
Better app names

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -1,12 +1,19 @@
 import React from 'react'
+import get from 'lodash/get'
 import { appShape } from 'proptypes/index'
+import { models } from 'cozy-client'
 
 import AppIcon from 'cozy-ui/react/AppIcon'
 import AppLinker from 'cozy-ui/react/AppLinker'
 import HomeIcon from 'components/Apps/IconCozyHome'
-import { translate } from 'cozy-ui/react/I18n'
 import stack from 'lib/stack'
 import PropTypes from 'prop-types'
+
+const getAppDisplayName = get(models, 'applications.getAppDisplayName', app => {
+  return app.namePrefix && app.namePrefix.toLowerCase() !== 'cozy'
+    ? `${app.namePrefix} ${app.name}`
+    : app.name
+})
 
 export class AppItem extends React.Component {
   /**
@@ -57,9 +64,10 @@ export class AppItem extends React.Component {
   }
 
   render() {
-    const { t, useHomeIcon, app } = this.props
+    const { useHomeIcon, app } = this.props
 
     const dataIcon = app.slug ? `icon-${app.slug}` : ''
+    const appName = getAppDisplayName(app)
 
     return (
       <AppLinker
@@ -68,9 +76,6 @@ export class AppItem extends React.Component {
         href={this.buildAppUrl(app.href) || ''}
       >
         {({ onClick, href }) => {
-          const label = t(`${app.slug}.name`, {
-            _: app.namePrefix ? `${app.namePrefix} ${app.name}` : app.name
-          })
           return (
             <li
               className={`coz-nav-apps-item${
@@ -81,7 +86,7 @@ export class AppItem extends React.Component {
                 role="menuitem"
                 href={href}
                 data-icon={dataIcon}
-                title={label}
+                title={appName}
                 onClick={onClick}
               >
                 {useHomeIcon ? (
@@ -94,7 +99,7 @@ export class AppItem extends React.Component {
                     {...stack.get.iconProps()}
                   />
                 )}
-                <p className="coz-label">{label}</p>
+                <p className="coz-label">{appName}</p>
               </a>
             </li>
           )
@@ -109,4 +114,4 @@ AppItem.propTypes = {
   useHomeIcon: PropTypes.bool
 }
 
-export default translate()(AppItem)
+export default AppItem

--- a/src/components/Settings/helper.js
+++ b/src/components/Settings/helper.js
@@ -1,26 +1,8 @@
-import compare from 'semver-compare'
-import client from 'lib/stack-client'
+import { compareClientVersion } from 'lib/stack-client'
 export const isFetchingQueries = requests => {
   return requests.some(request => request.fetchStatus === 'loading')
 }
-/**
- *
- * @param {cozyClient} forcedCozyClient only used to test purpose
- *
- * We can not read `version` from `import CozyClient from cozy-client`
- * since in that case, we'll read version from the cozy-bar node modules
- * and not from the app one.
- *
- * In order to avoid this issue, we get the cozyclient instance from
- * lib/stack-client (cozyclient's instance passed by the app to the bar),
- * then read the constructor and then read the version from it
- */
-export const cozyClientCanCheckPremium = (forcedCozyClient = null) => {
-  const usedClient = client.getClient() ? client.getClient().constructor : {}
-  const cozyClientToUse =
-    forcedCozyClient !== null ? forcedCozyClient : usedClient
 
-  if (!cozyClientToUse.version) return false
-  const result = compare(cozyClientToUse.version, '8.3.0')
-  return result >= 0
+export const cozyClientCanCheckPremium = () => {
+  return compareClientVersion('8.3.0')
 }

--- a/src/config/excludedApps.yaml
+++ b/src/config/excludedApps.yaml
@@ -1,1 +1,0 @@
-- settings

--- a/src/lib/reducers/apps.js
+++ b/src/lib/reducers/apps.js
@@ -1,6 +1,5 @@
 import stack from 'lib/stack'
 import unionWith from 'lodash.unionwith'
-import EXCLUDES from 'config/excludedApps'
 
 // constants
 const DELETE_APP = 'DELETE_APP'
@@ -46,9 +45,7 @@ export const fetchApps = () => async dispatch => {
   try {
     dispatch({ type: FETCH_APPS })
     const rawAppList = await stack.get.apps()
-    const apps = rawAppList
-      .filter(app => !EXCLUDES.includes(app.attributes.slug))
-      .map(mapApp)
+    const apps = rawAppList.map(mapApp)
     if (!rawAppList.length)
       throw new Error('No installed apps found by the bar')
     // TODO load only one time icons

--- a/src/lib/stack-client.js
+++ b/src/lib/stack-client.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-
+import compare from 'semver-compare'
 import { Intents } from 'cozy-interapp'
 import getIcon from 'lib/icon'
 import initializeRealtime from 'lib/realtime'
@@ -339,8 +339,25 @@ const getSettingsAppURL = function() {
   })
 }
 
-const getClient = function() {
-  return cozyClient
+/**
+ *
+ * @param {cozyClient} forcedCozyClient only used to test purpose
+ *
+ * We can not read `version` from `import CozyClient from cozy-client`
+ * since in that case, we'll read version from the cozy-bar node modules
+ * and not from the app one.
+ *
+ * In order to avoid this issue, we get the instance passed by the app to the bar),
+ * then read the constructor and then read the version from it
+ */
+const compareClientVersion = function(targetVersion, forcedCozyClient = null) {
+  const usedClient = cozyClient ? cozyClient.constructor : {}
+  const cozyClientToUse =
+    forcedCozyClient !== null ? forcedCozyClient : usedClient
+
+  if (!cozyClientToUse.version) return false
+  const result = compare(cozyClientToUse.version, targetVersion)
+  return result >= 0
 }
 
 /**
@@ -364,6 +381,8 @@ const init = function({ cozyClient: client, onCreate, onDelete }) {
   })
 }
 
+export { compareClientVersion }
+
 export default {
   get: {
     app: getApp,
@@ -378,6 +397,5 @@ export default {
   updateAccessToken,
   cozyFetchJSON,
   logout,
-  init,
-  getClient
+  init
 }

--- a/test/components/Settings/helper.spec.js
+++ b/test/components/Settings/helper.spec.js
@@ -1,7 +1,4 @@
-import {
-  isFetchingQueries,
-  cozyClientCanCheckPremium
-} from 'components/Settings/helper'
+import { isFetchingQueries } from 'components/Settings/helper'
 
 describe('Settings Helper', () => {
   it('should return true if isFetchingQueries', () => {
@@ -22,14 +19,5 @@ describe('Settings Helper', () => {
       fetchStatus: 'loaded'
     }
     expect(isFetchingQueries([fakeRequest1, fakeRequest2])).toBe(false)
-  })
-
-  it('should return true for cozyClientCanCheckPremium', () => {
-    const CozyClient = {
-      version: '6.7.8'
-    }
-
-    expect(cozyClientCanCheckPremium(CozyClient)).toBe(false)
-    expect(cozyClientCanCheckPremium({ version: '10.7.8' })).toBe(true)
   })
 })

--- a/test/components/__snapshots__/AppsContent.spec.jsx.snap
+++ b/test/components/__snapshots__/AppsContent.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`Apps Content should display home in the app items lists, if we are on m
   <ul
     className="coz-nav-group"
   >
-    <Wrapper
+    <AppItem
       app={
         Object {
           "slug": "cozy-home",
@@ -69,7 +69,7 @@ exports[`Apps Content should render display Drive 1`] = `
   <ul
     className="coz-nav-group"
   >
-    <Wrapper
+    <AppItem
       app={
         Object {
           "name": "Drive",

--- a/test/lib/stack-client/stack-client.compare.spec.js
+++ b/test/lib/stack-client/stack-client.compare.spec.js
@@ -1,0 +1,20 @@
+import { compareClientVersion } from 'lib/stack-client'
+
+describe('stack client', () => {
+  describe('compareClientVersion', () => {
+    it('should compare to target versions', () => {
+      const targetVersion = '6.7.8'
+      const CozyClient = {
+        version: '5.1.0'
+      }
+
+      expect(compareClientVersion(targetVersion, CozyClient)).toBe(false)
+
+      CozyClient.version = targetVersion
+      expect(compareClientVersion(targetVersion, CozyClient)).toBe(true)
+
+      CozyClient.version = '10.7.8'
+      expect(compareClientVersion(targetVersion, CozyClient)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
This PR brings the app list in line with the behavior on the home page:

- No Cozy prefix
- Support translated names
- Display Settings


I did 475512012cd1cb831ad2f2df425b13999114dcff anticipating I'd need it for using `applicationsModel`but didn't end up using it. I still think it's better like this but we can also remove this commit from the PR.
