### PR TITLE
fix: App name size should be 1rem

### DIFF
--- a/src/styles/apps.css
+++ b/src/styles/apps.css
@@ -18,6 +18,7 @@
   background-color: transparent;
   border: none;
   color: black;
+  font-size: 1rem;
 }
 
 [role=banner] .coz-nav-apps-btns-main:hover,


### PR DESCRIPTION
Fix for https://trello.com/c/6KHIM8PO
If an app doesn't load cozy-ui, normalize.css is missing and button default to 11px instead of 16px.
This change push the 1rem to a specific place to avoid having to load cozy-ui if not needed.