### PR TITLE
fix: Use cozy fork for minilog

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "localforage": "1.7.3",
     "lodash.debounce": "4.0.8",
     "lodash.unionwith": "4.6.0",
-    "minilog": "3.1.0",
+    "minilog": "https://github.com/cozy/minilog.git#master",
     "parcel": "1.12.3",
     "piwik-react-router": "0.12.1",
     "prop-types": "15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9462,6 +9462,12 @@ minilog@3.1.0:
   dependencies:
     microee "0.0.6"
 
+"minilog@https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"


### PR DESCRIPTION
We added a few functions in our minilog fork. We should use it ;) 