### PR TITLE
feat: Better default app support for self hosted cozy

### DIFF
--- a/src/lib/reducers/apps.spec.js
+++ b/src/lib/reducers/apps.spec.js
@@ -1,0 +1,59 @@
+import CozyClient from 'cozy-client'
+import client from 'lib/stack-client.js'
+import stack from 'lib/stack.js'
+import { setDefaultApp } from './apps'
+
+const cozyURL = 'https://test.mycozy.cloud'
+const token = 'mytoken'
+const fakeStackClient = {
+  uri: cozyURL,
+  token: { token }
+}
+describe('app reduceur', () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+    const params = {
+      cozyClient: new CozyClient({ fakeStackClient }),
+      onCreate: function() {},
+      onDelete: function() {}
+    }
+
+    stack.init(params)
+  })
+  it('dispatch RECEIVE_HOME_APP if context has default redirection', async () => {
+    jest.spyOn(client.get, 'context').mockResolvedValue({
+      data: { attributes: { default_redirection: 'home/' } }
+    })
+    const dispatchMock = jest.fn(x => x)
+
+    const setted = setDefaultApp([{ slug: 'home' }])
+    await setted(dispatchMock)
+    expect(dispatchMock).toHaveBeenCalledWith({
+      homeApp: { slug: 'home' },
+      type: 'RECEIVE_HOME_APP'
+    })
+  })
+
+  it('dispatch RECEIVE_HOME_APP with hardcoded home if context has no default redirection', async () => {
+    jest.spyOn(client.get, 'context').mockResolvedValue({})
+    const dispatchMock = jest.fn(x => x)
+
+    const setted = setDefaultApp([{ slug: 'home' }])
+    await setted(dispatchMock)
+    expect(dispatchMock).toHaveBeenCalledWith({
+      homeApp: { slug: 'home' },
+      type: 'RECEIVE_HOME_APP'
+    })
+  })
+
+  it('dispatch nothing if the default redirection if not in the apps array', async () => {
+    jest.spyOn(client.get, 'context').mockResolvedValue({
+      data: { attributes: { default_redirection: 'drive/' } }
+    })
+    const dispatchMock = jest.fn(x => x)
+
+    const setted = setDefaultApp([{ slug: 'home' }])
+    await setted(dispatchMock)
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/reducers/apps.spec.js
+++ b/src/lib/reducers/apps.spec.js
@@ -9,7 +9,7 @@ const fakeStackClient = {
   uri: cozyURL,
   token: { token }
 }
-describe('app reduceur', () => {
+describe('app reducer', () => {
   beforeAll(() => {
     jest.clearAllMocks()
     const params = {


### PR DESCRIPTION
We make a request to /settings/context to get the "Default App", in order to make the link "Back to home" in the cozy bar. But with a self hosted cozy, we don't have a context by default and we don't have a default home slug defined.

So two solutions: 
- self hosted can create a context and add a default_redirection param equal to "home/"
- Edit the cozy bar to get the "HOME" slug if the default_redirection is not defined. 

I renamed homeApp to DefaultApp since we can have a different app 