### PR TITLE
fix: Do not use export default but only export

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -214,7 +214,7 @@ const {
 
 const version = __VERSION__
 
-export default {
+export {
   init,
   version,
   setBarCenter,

--- a/src/index.spec.jsx
+++ b/src/index.spec.jsx
@@ -1,5 +1,5 @@
 import CozyClient from 'cozy-client'
-import cozyBar from './index'
+import * as cozyBar from './index'
 
 describe('init', () => {
   beforeEach(() => {


### PR DESCRIPTION
Otherwise we have to do cozy.bar.default.init