### PR TITLE
fix: Deactivate cssmodules when transpiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "travis-deploy-once": "travis-deploy-once",
     "example": "env USE_REACT=true nf -j examples/Procfile start",
     "transpile:js": "env BABEL_ENV=transpilation babel -D src/ --out-dir transpiled/ --verbose",
-    "transpile:css": "node_modules/.bin/stylus src/styles/index.styl -u ./node_modules/cozy-ui/stylus/index.js -o transpiled/cozy-bar.css",
+    "transpile:css": "env CSSMODULES=false node_modules/.bin/stylus src/styles/index.styl -u ./node_modules/cozy-ui/stylus/index.js -o transpiled/cozy-bar.css",
     "transpile": "yarn run transpile:js && yarn run transpile:css"
   },
   "devDependencies": {


### PR DESCRIPTION
cozy-ui stylus utility helpers behave differently if we have CSSMODULES
to true or false. If the CSSMODULES is not set to false, we end up
with :global selectors in the resulting CSS file. This does not work
well with safari which ignores the rules under :global.