### PR TITLE
Remove cozy-client warning

### DIFF
--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,20 +1,16 @@
+import { Q } from 'cozy-client'
+
 export const instanceReq = {
-  query: client => {
-    return client.get('io.cozy.settings', 'instance')
-  },
+  query: () => Q('io.cozy.settings').getById('instance'),
   as: 'instanceQuery'
 }
 
 export const contextReq = {
-  query: client => {
-    return client.get('io.cozy.settings', 'context')
-  },
+  query: () => Q('io.cozy.settings').getById('context'),
   as: 'contextQuery'
 }
 
 export const diskUsageReq = {
-  query: client => {
-    return client.get('io.cozy.settings', 'disk-usage')
-  },
+  query: () => Q('io.cozy.settings').getById('disk-usage'),
   as: 'diskUsageQuery'
 }


### PR DESCRIPTION
client.get is deprecated. Q is preferred as it can be used statically (no
need for a cozy-client) and more versatile as you can build any query
with it (with client.find and client.get, you are limited, to Q::where()
and Q::getById()).