### PR TITLE
ci: Make max bundlesize higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   "bundlesize": [
     {
       "path": "./dist/cozy-bar.min.js",
-      "maxSize": "300 KB"
+      "maxSize": "350 KB"
     }
   ],
   "jest": {


### PR DESCRIPTION
This is necessary after the new features added to cozy-bar.
No way around it at the moment, best would be to remove react