### PR TITLE
fix: Always display home icon in Webview

### DIFF
--- a/src/components/Apps/ButtonCozyHome.jsx
+++ b/src/components/Apps/ButtonCozyHome.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
+import { isFlagshipApp } from 'cozy-device-helper'
 
 import flag from 'cozy-flags'
 
 import IconCozyHome from './IconCozyHome'
 
 export const ButtonCozyHome = ({ webviewContext, homeHref }) => {
-  if (webviewContext || flag('flagship.debug'))
+  if (isFlagshipApp() || flag('flagship.debug'))
     return (
       <a
         onClick={() => {

--- a/src/components/Apps/ButtonCozyHome.spec.jsx
+++ b/src/components/Apps/ButtonCozyHome.spec.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-
 import { ButtonCozyHome } from './ButtonCozyHome'
+import { isFlagshipApp } from 'cozy-device-helper'
+
+jest.mock('cozy-device-helper')
 
 const homeHref = 'foo'
 const expectedCall = 'backToHome'
@@ -11,6 +13,7 @@ const webviewContext = {
 
 describe('ButtonCozyHome', () => {
   it('should render a span with no props', () => {
+    isFlagshipApp.mockImplementation(() => false)
     const render = shallow(<ButtonCozyHome />)
     const element = render.getElement()
 
@@ -18,6 +21,7 @@ describe('ButtonCozyHome', () => {
   })
 
   it('should render an anchor with correct href when homeHref', () => {
+    isFlagshipApp.mockImplementation(() => false)
     const render = shallow(<ButtonCozyHome homeHref={homeHref} />)
     const element = render.getElement()
 
@@ -25,14 +29,16 @@ describe('ButtonCozyHome', () => {
     expect(element.props.href).toBe(homeHref)
   })
 
-  it('should render an anchor when webviewContext', () => {
+  it('should render an anchor when isFlagshipApp', () => {
+    isFlagshipApp.mockImplementation(() => true)
     const render = shallow(<ButtonCozyHome webviewContext={webviewContext} />)
     const element = render.getElement()
 
     expect(element.type).toBe('a')
   })
 
-  it('should give priority to anchor if both webviewContext and homeHref are present', () => {
+  it('should give priority to anchor if both isFlagshipApp and homeHref are present', () => {
+    isFlagshipApp.mockImplementation(() => true)
     const render = shallow(
       <ButtonCozyHome homeHref={homeHref} webviewContext={webviewContext} />
     )
@@ -42,6 +48,7 @@ describe('ButtonCozyHome', () => {
   })
 
   it('should call the correct context method on click', () => {
+    isFlagshipApp.mockImplementation(() => true)
     const render = shallow(
       <ButtonCozyHome homeHref={homeHref} webviewContext={webviewContext} />
     )

--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -10,7 +10,7 @@ import {
   getTracker,
   configureTracker
 } from 'cozy-ui/react/helpers/tracker'
-import { isMobileApp } from 'cozy-device-helper'
+import { isFlagshipApp, isMobileApp } from 'cozy-device-helper'
 import flag from 'cozy-flags'
 
 import { ButtonCozyHome } from 'components/Apps/ButtonCozyHome'
@@ -166,7 +166,7 @@ export class Bar extends Component {
   renderLeft = () => {
     const { t, isPublic, webviewContext } = this.props
 
-    if (webviewContext || flag('flagship.debug')) {
+    if (isFlagshipApp() || flag('flagship.debug')) {
       return <ButtonCozyHome webviewContext={webviewContext} />
     }
 


### PR DESCRIPTION
In case of race condition, error handling is done by native javascript
(can't call() from undefined)