### PR TITLE
fix: Use correct dimensions on flagship buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-bar",
-  "version": "7.17.8",
+  "version": "7.17.9",
   "description": "cozy-bar.js library, a small lib provided by cozy-stack to inject the Cozy-bar component into each app",
   "main": "dist/cozy-bar.js",
   "author": "Cozy Cloud <contact@cozycloud.cc> (https://cozy.io/)",

--- a/src/styles/apps.css
+++ b/src/styles/apps.css
@@ -53,9 +53,11 @@
 [role=banner] .coz-nav-apps-btns-home.--is-flagship {
   align-items: center;
   display: flex;
+  flex-shrink: 0;
   height: 100%;
-  margin: 0;
-  padding: 0 1rem;
+  justify-content: center;
+  margin-right: .25rem;
+  width: 3rem;
 }
 
 


### PR DESCRIPTION
- 48x48 container, 32x32 img, marginRight 4px
- Aligned center on X and Y axis

➡ As per the design spec

https://trello.com/c/tKnoBX2y/336-%F0%9F%90%9B-clignotement-du-titre-de-lapp-%C3%A0-louverture-dune-application