### PR TITLE
fix: Dep & PeerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,13 @@
     "bundlesize": "0.18.0",
     "cozy-authentication": "1.19.1",
     "cozy-intent": "^1.7.0",
+    "@cozy/minilog": "^1.0.0",
+    "cozy-client": "^27.17.0",
+    "cozy-device-helper": "1.17.0",
+    "cozy-flags": "^2.8.5",
+    "cozy-interapp": "0.4.9",
+    "cozy-realtime": "^4.0.5",
+    "cozy-ui": "^51.8.0",
     "css-loader": "1.0.1",
     "css-mqpacker": "7.0.0",
     "cssnano-preset-advanced": "4.0.7",
@@ -95,13 +102,6 @@
     "webpack-merge": "4.2.2"
   },
   "dependencies": {
-    "@cozy/minilog": "^1.0.0",
-    "cozy-client": "^27.17.0",
-    "cozy-device-helper": "1.17.0",
-    "cozy-flags": "^2.8.5",
-    "cozy-interapp": "0.4.9",
-    "cozy-realtime": "^4.0.5",
-    "cozy-ui": "^51.8.0",
     "hammerjs": "2.0.8",
     "lodash.debounce": "4.0.8",
     "lodash.set": "^4.3.2",
@@ -115,8 +115,14 @@
     "semver-compare": "^1.0.0"
   },
   "peerDependencies": {
-    "cozy-client": "*",
-    "cozy-intent": ">=1.7.0"
+    "cozy-intent": ">=1.7.0",
+    "@cozy/minilog": "^1.0.0",
+    "cozy-client": "^27.17.0",
+    "cozy-device-helper": "1.17.0",
+    "cozy-flags": "^2.8.5",
+    "cozy-interapp": "0.4.9",
+    "cozy-realtime": "^4.0.5",
+    "cozy-ui": "^51.8.0"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
We have issue when installing cozy-bar >= 8.4.0 & cozy-client >= 27.10.X.  

By removing the need of "dep" and changing them to peerDep & devDep, it solves the issue. 

Issue was: 
An unexpected error occurred: "expected hoisted manifest for \"cozy-bar#cozy-client#cozy-ui\"