### PR TITLE
fix: Make sure searchbar doesn't render

### DIFF
--- a/src/components/Bar.jsx
+++ b/src/components/Bar.jsx
@@ -44,7 +44,8 @@ export class Bar extends Component {
       drawerVisible: false,
       usageTracker: null,
       supportDisplayed: false,
-      searchBarEnabled: props.isDrive && !props.isPublic && !isMobileApp()
+      searchBarEnabled:
+        props.isDrive && !props.isPublic && !isMobileApp() && !isFlagshipApp()
     }
     this.fetchApps = this.fetchApps.bind(this)
     this.fetchInitialData = this.fetchInitialData.bind(this)


### PR DESCRIPTION
If searchbar ever renders in FlagshipApp, this will currently trigger
a breaking bug with iframes CSP issues.
As of now we just ask the cozybar to not render the searchbar when
we're in flagship so the issue does not exist