### PR TITLE
feat(SearchBar): fetch and open note once clicked on a suggestion

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -234,10 +234,9 @@ class SearchBar extends Component {
     // `onSelect` is a string that describes what should happen when the suggestion is selected. Currently, the only format we're supporting is `open:http://example.com` to change the url of the current page.
 
     if (typeof onSelect === 'function') {
-      await onSelect()
+      window.location.href = `open:` + (await onSelect())
     } else if (/^open:/.test(onSelect)) {
-      const url = onSelect.substr(5)
-      window.location.href = url
+      window.location.href = onSelect.substr(5)
     } else {
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
Problem was detected by:
https://github.com/cozy/cozy-drive/pull/2663?notification_referrer_id=NT_kwDOAH-dRrI0MTM4NzMwMjUyOjgzNjMzMzQ&notifications_query=is%3Aunread#discussion_r946530786

notes URL were not used to redirect, once clicked.

By fixing that bug, I realized the postMessage onSelect function could not be sent through postMessage. Becasue postMessage serializes the object before sending it.
[An object could not be cloned](https://stackoverflow.com/questions/42376464/uncaught-domexception-failed-to-execute-postmessage-on-window-an-object-co)

Fetching URL is now done inside Cozy-Bar scope