### PR TITLE
fix(warning): mark as UNSAFE component will mount

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -105,7 +105,7 @@ class SearchBar extends Component {
 
   sources = []
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.debouncedOnSuggestionsFetchRequested = debounce(
       this.onSuggestionsFetchRequested,
       250


### PR DESCRIPTION
it removes warnings in Drive cause by Searchbar