### PR TITLE
fix(styles): Safari margin of Settings Menu are removed

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -39,6 +39,7 @@
 }
 [role=banner] .coz-nav-settings-item .coz-nav-settings-item-btn[role=menuitem] {
   padding-left: 1.5rem;
+  display: initial;
 }
 [role=banner] .coz-nav-settings-item .coz-nav-settings-item-btn[role=menuitem] > span > span {
   margin-right: auto;


### PR DESCRIPTION
An extra spacing came only on Safari browser

removing display block prevents the extra margin