### PR TITLE
feat: Launch stack request on focus

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -173,6 +173,19 @@ class SearchBar extends Component {
   }
 
   changeFocusState = focused => {
+    // hack in order to launch the stack request on drive.
+    // it'll be solved by using v8 or v9 bar on Drive
+    const availableSources = this.sources.filter(source => source.ready)
+    availableSources.forEach(async source => {
+      await new Promise(resolve => {
+        const resolverId = new Date().getTime().toString()
+        source.resolvers[resolverId] = resolve
+        source.window.postMessage(
+          { query: 'fakedata', id: resolverId },
+          source.origin
+        )
+      })
+    })
     this.setState({
       focused
     })


### PR DESCRIPTION
Since we send a (fake) message via postMessage,
Cozy Drive's intent will catch it and
send the _all_docs request. Like that
we warm up the query and the data and
we expect to give a better UX like that.