### PR TITLE
fix: AppLinker needs app props now

### DIFF
--- a/src/components/Apps/AppItem.jsx
+++ b/src/components/Apps/AppItem.jsx
@@ -65,7 +65,6 @@ export class AppItem extends React.Component {
 
   render() {
     const { useHomeIcon, app } = this.props
-
     const dataIcon = app.slug ? `icon-${app.slug}` : ''
     const appName = getAppDisplayName(app)
 
@@ -74,6 +73,7 @@ export class AppItem extends React.Component {
         onAppSwitch={this.onAppSwitch}
         slug={app.slug}
         href={this.buildAppUrl(app.href) || ''}
+        app={app}
       >
         {({ onClick, href }) => {
           return (


### PR DESCRIPTION
AppLinker needs app props now. Specially within the flagship app. 

`app` props is required and it's a BC of cozy-ui. We didn't upgrade the call yet. This is now done. 