### PR TITLE
feat: add translations for banner moved (VO-46)

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -21,12 +21,14 @@ const Banner = ({ code, links }) => {
   return (
     <div className={`coz-bar-banner${unmounted ? ' unmounted' : ''}`}>
       <p>{t(`banner.${code}.description`)}</p>
-      <ButtonLink
-        className="coz-bar-banner-button"
-        size="tiny"
-        href={links}
-        label={t(`banner.${code}.CTA`)}
-      />
+      {links && (
+        <ButtonLink
+          className="coz-bar-banner-button"
+          size="tiny"
+          href={links}
+          label={t(`banner.${code}.CTA`)}
+        />
+      )}
     </div>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,9 @@
     "tos-updated": {
       "description": "To comply with the GDPR, Cozy Cloud has updated its Terms of Services that have taken effect on May 25, 2018",
       "CTA": "Read now"
+    },
+    "moved": {
+      "description": "The Cozy has been moved to a new address"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -42,6 +42,9 @@
     "tos-updated": {
       "description": "Dans le cadre du RGPD, Cozy Cloud met à jour ses Conditions Générales d'Utilisation qui ont pris effet le 25 Mai 2018",
       "CTA": "Lire maintenant"
+    },
+    "moved": {
+      "description": "Ce Cozy a été déplacé vers une nouvelle adresse"
     }
   }
 }


### PR DESCRIPTION
If the html document contains a "moved" descriptor, we will display the correct translation.
Also, we won't display banner CTA as there is no link available in the metadata.