### PR TITLE
fix: Do not rely on `.attributes` on StorageData

### DIFF
--- a/src/components/Settings/StorageData.jsx
+++ b/src/components/Settings/StorageData.jsx
@@ -14,9 +14,9 @@ const StorageData = () => {
 
   // we used this default quota set in getStorageData, we just reuse it here
   const storageData = makeDiskInfos(
-    diskUsage.data.attributes.used,
-    diskUsage.data.attributes.quota ||
-      Math.max(10 ** 12, 10 * parseInt(diskUsage.data.attributes.used, 10))
+    diskUsage.data.used,
+    diskUsage.data.quota ||
+      Math.max(10 ** 12, 10 * parseInt(diskUsage.data.used, 10))
   )
 
   return (


### PR DESCRIPTION
When the app is served offline, then the PouchDB result would not contain any `.attribute` property, instead we should access properties from the document's root