### PR TITLE
[PRD-538] feat: Hide apps by flag

### DIFF
--- a/src/lib/reducers/apps.js
+++ b/src/lib/reducers/apps.js
@@ -1,5 +1,6 @@
 import stack from 'lib/stack'
 import unionWith from 'lodash.unionwith'
+import flag from 'cozy-flags'
 
 // constants
 const DELETE_APP = 'DELETE_APP'
@@ -46,7 +47,10 @@ export const fetchApps = () => async dispatch => {
   try {
     dispatch({ type: FETCH_APPS })
     const rawAppList = await stack.get.apps()
-    const apps = rawAppList.map(mapApp)
+    const excludedApps = flag('apps.hidden') || []
+    const apps = rawAppList
+      .map(mapApp)
+      .filter(app => !excludedApps.includes(app))
     if (!rawAppList.length)
       throw new Error('No installed apps found by the bar')
     // TODO load only one time icons


### PR DESCRIPTION
The `apps.hidden` flag will be used to hide apps in home, store and bar