### PR TITLE
fix: Close modals when navigating

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cozy-logger": "1.9.1",
     "cozy-realtime": "^4.0.5",
     "cozy-search": "^0.4.0",
-    "cozy-ui": "^122.6.0",
+    "cozy-ui": "^122.12.1",
     "eslint-config-cozy-app": "2.0.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.9.0",
@@ -86,7 +86,7 @@
     "cozy-interapp": ">=0.4.9",
     "cozy-realtime": ">=4.0.5",
     "cozy-search": ">=0.4.0",
-    "cozy-ui": ">=122.6.0",
+    "cozy-ui": ">=122.12.1",
     "react": ">=16.10.1",
     "react-dom": ">=16.10.1",
     "react-router-dom": ">=6.14.2"

--- a/src/components/AppsMenu/AppsMenuContent.jsx
+++ b/src/components/AppsMenu/AppsMenuContent.jsx
@@ -12,7 +12,7 @@ import useI18n from 'components/useI18n'
 import { getApps, getHomeApp, isFetchingApps } from 'lib/reducers'
 import styles from 'styles/apps-menu.styl'
 
-export const AppsMenuContent = ({ isFetchingApps, apps, homeApp }) => {
+const AppsMenuContent = ({ isFetchingApps, apps, homeApp, closeMenu }) => {
   const { t } = useI18n()
 
   if (!isFetchingApps && (!apps || !apps.length)) {
@@ -44,21 +44,21 @@ export const AppsMenuContent = ({ isFetchingApps, apps, homeApp }) => {
   return (
     <div className={styles['apps-menu-grid']}>
       {sortedApps.map((app, index) => (
-        <AppItem key={index} app={app} />
+        <AppItem key={index} app={app} onAppSwitch={closeMenu} />
       ))}
     </div>
   )
 }
 
 AppsMenuContent.propTypes = {
-  apps: PropTypes.array,
   isFetchingApps: PropTypes.bool.isRequired,
+  apps: PropTypes.array,
   homeApp: PropTypes.shape({
     isCurrentApp: PropTypes.bool,
     slug: PropTypes.string,
     href: PropTypes.string
   }),
-  className: PropTypes.string
+  closeMenu: PropTypes.func
 }
 
 const mapStateToProps = state => ({

--- a/src/components/AppsMenu/components/AppItem.jsx
+++ b/src/components/AppsMenu/components/AppItem.jsx
@@ -23,13 +23,13 @@ const useStyles = makeStyles(() => {
   }
 })
 
-export const AppItem = ({ app }) => {
+export const AppItem = ({ app, onAppSwitch }) => {
   const appName = getAppDisplayName(app)
 
   const classes = useStyles()
 
   return (
-    <AppLinker href={app.href || ''} app={app}>
+    <AppLinker href={app.href || ''} app={app} onAppSwitch={onAppSwitch}>
       {({ onClick, href }) => {
         return (
           <Buttons

--- a/src/components/AppsMenu/index.jsx
+++ b/src/components/AppsMenu/index.jsx
@@ -42,7 +42,7 @@ const AppsMenu = () => {
         <ConfirmDialog
           open={isOpen}
           onClose={toggleMenu}
-          content={<AppsMenuContent />}
+          content={<AppsMenuContent closeMenu={toggleMenu} />}
           componentsProps={{
             dialogContent: {
               classes: styles
@@ -71,7 +71,7 @@ const AppsMenu = () => {
             paper: 'u-bdrs-7'
           }}
         >
-          <AppsMenuContent />
+          <AppsMenuContent closeMenu={toggleMenu} />
         </Menu>
       )}
     </nav>

--- a/src/components/UserMenu/UserMenuContent.jsx
+++ b/src/components/UserMenu/UserMenuContent.jsx
@@ -26,7 +26,7 @@ import styles from 'styles/user-menu.styl'
 import AvatarMyself from './components/AvatarMyself'
 import { getSettingsLink, logOut } from './helpers'
 
-export const UserMenuContent = ({ onLogOut, instance, diskUsage }) => {
+const UserMenuContent = ({ onLogOut, instance, diskUsage, closeMenu }) => {
   const webviewIntent = useWebviewIntent()
 
   const client = useClient()
@@ -69,6 +69,7 @@ export const UserMenuContent = ({ onLogOut, instance, diskUsage }) => {
           size="small"
           component="a"
           href={profileLink}
+          onClick={closeMenu}
         >
           <ListItemIcon>
             <Icon icon={FromUserIcon} />
@@ -89,6 +90,7 @@ export const UserMenuContent = ({ onLogOut, instance, diskUsage }) => {
           size="small"
           component="a"
           href={storageLink}
+          onClick={closeMenu}
         >
           <ListItemIcon>
             <Icon icon={CloudRainbowIcon} />

--- a/src/components/UserMenu/index.jsx
+++ b/src/components/UserMenu/index.jsx
@@ -54,6 +54,7 @@ const UserMenu = ({ onLogOut }) => {
               onLogOut={onLogOut}
               instance={instance}
               diskUsage={diskUsage}
+              closeMenu={toggleMenu}
             />
           }
           componentsProps={{
@@ -88,6 +89,7 @@ const UserMenu = ({ onLogOut }) => {
             onLogOut={onLogOut}
             instance={instance}
             diskUsage={diskUsage}
+            closeMenu={toggleMenu}
           />
         </Menu>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,10 +3505,10 @@ cozy-stack-client@^57.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^122.6.0:
-  version "122.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-122.6.0.tgz#2ca14ae8205bab622cd2f50915d86a6065f3cc42"
-  integrity sha512-zvfiA4VGdMxgPfEkYGPBsujA6o+3+eQuynVIGGTmu7FkvJjx74zkj+kAixbbinWn1xlYhR3lQcJeJkl4iEacog==
+cozy-ui@^122.12.1:
+  version "122.12.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-122.12.1.tgz#58c88823643a112d5c4b58e308c6c374b3a8cbf6"
+  integrity sha512-jrXzAhcVZAwN1Y+ikdlSnSbzKPPb0M7x5cKltTQWeJI75iGtt1477WdPfGPUhbEj1/BTXFURBAPchNWjlGT7Fg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"


### PR DESCRIPTION
Solves to issues :
- If I am on settings on "Appearance" page and I click on "Manage profile" from cozy-bar UserMenu, it will navigate to "Profile" page but the UserMenu stayed open
- On flagship app, we need to close the AppsMenu when opening a app because the home is always alive in a separate webview. So when we were going back to the home,  the UserMenu stayed open

Todo : 
- [x] update cozy-client (BC) https://github.com/cozy/cozy-ui/pull/2787