### PR TITLE
fix: Avoid strech in bar avatar

### DIFF
--- a/src/components/UserMenu/components/AvatarMyself.jsx
+++ b/src/components/UserMenu/components/AvatarMyself.jsx
@@ -8,13 +8,11 @@ const AvatarMyself = ({ className, size = 'm' }) => {
   const rootURL = client.getStackClient().uri
 
   return (
-    <Avatar className={className} size={size}>
-      <img
-        width="100%"
-        height="100%"
-        src={`${rootURL}/public/avatar?fallback=initials`}
-      />
-    </Avatar>
+    <Avatar
+      className={className}
+      size={size}
+      src={`${rootURL}/public/avatar?fallback=initials`}
+    />
   )
 }
 


### PR DESCRIPTION
By using src attribute of Avatar from mui to display a picture, we benefit from mui classes and object-fit: 'cover'.